### PR TITLE
Address PR #12 review feedback (1.1.0 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Keeper Security JetBrains Plugin Changelog
 
+## [Unreleased]
+
 ## [1.1.0] - 2026-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Keeper Security JetBrains Plugin Changelog
 
-## [Unreleased]
+## [1.1.0] - 2026-05-07
 
 ### Added
 - **Run Keeper Securely** as a saved run configuration (**Run → Edit Configurations**): `.env` path, working directory, command, output in the Run tool window; defaults for Python SDK / venv and common entry scripts when creating a new configuration

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 
 pluginGroup = com.keepersecurity.jetbrains
 pluginName = Keeper Security
-pluginRepositoryUrl = https://github.com/[your-username]/keeper-jetbrains-plugin
+pluginRepositoryUrl = https://github.com/Keeper-Security/keeper-jetbrains-plugin
 # SemVer format -> https://semver.org
 pluginVersion = 1.1.0
 

--- a/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
@@ -1,10 +1,12 @@
 package keepersecurity.action
 
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
@@ -261,7 +263,8 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
 
                                 val selectedFieldKey = fieldOptions.find { it.first == selectedFieldDisplay }?.second ?: return@invokeLater
                                 val keeperNotation = "keeper://$selectedUid/field/$selectedFieldKey"
-                                val insertText = insertionTextForCurrentFile(editor, selectedUid, selectedFieldKey, keeperNotation)
+                                val isHttpFile = isHttpClientRequestFile(editor)
+                                val insertText = insertionTextFor(isHttpFile, selectedUid, selectedFieldKey, keeperNotation)
 
                                 logger.info("Insert text for editor: ${insertText.take(120)}…")
 
@@ -275,7 +278,7 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
                                 // Show success message
                                 Messages.showInfoMessage(
                                     project,
-                                    buildInsertionSuccessMessage(insertText, keeperNotation),
+                                    buildInsertionSuccessMessage(isHttpFile, insertText, keeperNotation),
                                     "Keeper Reference Added",
                                 )
                             }
@@ -297,23 +300,35 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
      * In JetBrains HTTP Client files (`.http` / `.rest`), insert the `$keeper` dynamic variable
      * so users do not need to paste the record UID manually. Elsewhere, keep `keeper://…` for .env and scripts.
      */
-    private fun insertionTextForCurrentFile(
-        editor: Editor,
+    private fun insertionTextFor(
+        isHttpFile: Boolean,
         recordUid: String,
         fieldPath: String,
         keeperUriNotation: String,
-    ): String {
-        val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return keeperUriNotation
-        return if (isHttpClientRequestFile(file)) {
-            httpKeeperDynamicVariableSnippet(recordUid, fieldPath)
-        } else {
-            keeperUriNotation
+    ): String = if (isHttpFile) {
+        httpKeeperDynamicVariableSnippet(recordUid, fieldPath)
+    } else {
+        keeperUriNotation
+    }
+
+    /**
+     * Detects HTTP Client request files via the FileType API. The `com.jetbrains.restClient`
+     * plugin is an optional dependency, so its classes are only on the classpath when it is
+     * loaded; the plugin check plus the try/catch keep the call safe on IDEs that do not bundle it.
+     */
+    private fun isHttpClientRequestFile(editor: Editor): Boolean {
+        val file: VirtualFile = FileDocumentManager.getInstance().getFile(editor.document) ?: return false
+        if (!isHttpClientPluginEnabled()) return false
+        return try {
+            file.fileType == com.intellij.httpClient.http.request.HttpRequestFileType.INSTANCE
+        } catch (_: Throwable) {
+            false
         }
     }
 
-    private fun isHttpClientRequestFile(file: VirtualFile): Boolean {
-        val ext = file.extension ?: return false
-        return ext.equals("http", ignoreCase = true) || ext.equals("rest", ignoreCase = true)
+    private fun isHttpClientPluginEnabled(): Boolean {
+        val descriptor = PluginManagerCore.getPlugin(PluginId.getId("com.jetbrains.restClient"))
+        return descriptor != null && descriptor.isEnabled
     }
 
     /**
@@ -326,13 +341,14 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
         return "{{\$keeper(\"$uidEsc\",\"$fieldEsc\")}}"
     }
 
-    private fun buildInsertionSuccessMessage(insertText: String, keeperNotation: String): String {
-        val isHttpSnippet = insertText.startsWith("{{") && insertText.contains("keeper(")
-        return if (isHttpSnippet) {
-            "HTTP Client variable inserted (record and field chosen from the list — no UID to type).\n\n$insertText"
-        } else {
-            "Keeper reference inserted!\n\n$keeperNotation"
-        }
+    private fun buildInsertionSuccessMessage(
+        isHttpSnippet: Boolean,
+        insertText: String,
+        keeperNotation: String,
+    ): String = if (isHttpSnippet) {
+        "HTTP Client variable inserted (record and field chosen from the list — no UID to type).\n\n$insertText"
+    } else {
+        "Keeper reference inserted!\n\n$keeperNotation"
     }
 
     private fun showError(project: Project, message: String) {

--- a/src/main/kotlin/keepersecurity/http/KeeperHttpSecretResolver.kt
+++ b/src/main/kotlin/keepersecurity/http/KeeperHttpSecretResolver.kt
@@ -19,12 +19,16 @@ object KeeperHttpSecretResolver {
 
     /**
      * Fetches a Keeper record via the persistent shell and returns the requested field value.
+     *
+     * Throws on any failure (invalid input, missing field, shell error). The HTTP Client surfaces
+     * the throw as a variable-resolution error and skips the request, rather than substituting the
+     * error message into the URL, headers, or body.
      */
     fun resolveRecordField(recordUid: String, fieldPath: String, logger: Logger): String {
         val trimmedUid = recordUid.trim()
         val trimmedField = fieldPath.trim()
         if (trimmedUid.isEmpty() || trimmedField.isEmpty()) {
-            return "[Keeper] record UID and field path must be non-empty"
+            throw IllegalArgumentException("Keeper record UID and field path must be non-empty")
         }
 
         return try {
@@ -35,10 +39,12 @@ object KeeperHttpSecretResolver {
                 trimmedField,
                 logger,
             )
-            extracted ?: "[Keeper] Field '$trimmedField' not found in record $trimmedUid"
+            extracted ?: throw IllegalStateException(
+                "Keeper field '$trimmedField' not found in record $trimmedUid",
+            )
         } catch (e: Exception) {
             logger.warn("Keeper HTTP variable resolution failed: ${e.message}", e)
-            "[Keeper] ${e.message ?: e::class.simpleName}"
+            throw e
         }
     }
 

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureProcessHandler.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureProcessHandler.kt
@@ -4,6 +4,7 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
@@ -11,6 +12,10 @@ import java.io.File
 
 /**
  * Runs [KeeperSecureScriptRunner] asynchronously and streams output into the Run tool window.
+ *
+ * Secret-fetching has to run before the user command can spawn, so the work is launched from
+ * [startNotify]. The spawned [Process] and [ProgressIndicator] are stored as `@Volatile` fields
+ * so [destroyProcessImpl] can cancel an in-flight fetch and terminate the user command.
  */
 class KeeperSecureProcessHandler(
     private val project: Project,
@@ -20,6 +25,12 @@ class KeeperSecureProcessHandler(
 ) : ProcessHandler() {
 
     private val logger = thisLogger()
+
+    @Volatile
+    private var userProcess: Process? = null
+
+    @Volatile
+    private var runIndicator: ProgressIndicator? = null
 
     override fun detachProcessImpl() {
     }
@@ -32,6 +43,7 @@ class KeeperSecureProcessHandler(
         super.startNotify()
         object : Task.Backgroundable(project, "Run Keeper securely", true) {
             override fun run(indicator: ProgressIndicator) {
+                runIndicator = indicator
                 try {
                     val result = KeeperSecureScriptRunner.run(
                         project,
@@ -40,6 +52,7 @@ class KeeperSecureProcessHandler(
                         command,
                         indicator,
                         logger,
+                        onProcessStarted = { p -> userProcess = p },
                     )
                     ApplicationManager.getApplication().invokeLater {
                         if (result.scriptOutput.isNotEmpty()) {
@@ -54,6 +67,12 @@ class KeeperSecureProcessHandler(
                         val code = if (result.exitCode >= 0) result.exitCode else 1
                         notifyProcessTerminated(code)
                     }
+                } catch (_: ProcessCanceledException) {
+                    logger.info("Run Keeper Securely cancelled by user")
+                    ApplicationManager.getApplication().invokeLater {
+                        notifyTextAvailable("Cancelled by user\n", ProcessOutputTypes.STDERR)
+                        notifyProcessTerminated(-1)
+                    }
                 } catch (e: Exception) {
                     logger.error("Run Keeper Securely failed", e)
                     ApplicationManager.getApplication().invokeLater {
@@ -63,12 +82,16 @@ class KeeperSecureProcessHandler(
                         )
                         notifyProcessTerminated(-1)
                     }
+                } finally {
+                    userProcess = null
+                    runIndicator = null
                 }
             }
         }.queue()
     }
 
     override fun destroyProcessImpl() {
-        // Background task cancellation could be wired here if needed
+        runIndicator?.cancel()
+        userProcess?.destroyForcibly()
     }
 }

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureRunConfigurationEditor.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureRunConfigurationEditor.kt
@@ -43,15 +43,14 @@ class KeeperSecureRunConfigurationEditor(@Suppress("UNUSED_PARAMETER") project: 
 
     override fun applyEditorTo(s: KeeperSecureRunConfiguration) {
         val o = s.options
-        val env = envFileField.text.trim().ifBlank { ".env" }
-        o.envFilePath = env
+        o.envFilePath = envFileField.text.trim()
         o.workingDirectoryPath = workingDirField.text.trim()
         o.command = commandField.text.trim()
     }
 
     override fun resetEditorFrom(s: KeeperSecureRunConfiguration) {
         val o = s.options
-        envFileField.text = (o.envFilePath ?: "").ifBlank { ".env" }
+        envFileField.text = o.envFilePath.orEmpty()
         workingDirField.text = o.workingDirectoryPath.orEmpty()
         commandField.text = o.command.orEmpty()
     }

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureRunConfigurationType.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureRunConfigurationType.kt
@@ -1,6 +1,5 @@
 package keepersecurity.run
 
-import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationTypeBase
 import com.intellij.execution.configurations.RunConfiguration
@@ -29,11 +28,5 @@ class KeeperSecureRunConfigurationType : ConfigurationTypeBase(
         override fun getName(): String = "Run Keeper Securely"
 
         override fun isConfigurationSingletonByDefault(): Boolean = false
-
-        override fun configureDefaultSettings(settings: RunnerAndConfigurationSettings) {
-            super.configureDefaultSettings(settings)
-            val cfg = settings.configuration as? KeeperSecureRunConfiguration ?: return
-            KeeperSecureRunDefaults.applyDefaults(cfg.project, cfg.options)
-        }
     }
 }

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
@@ -1,6 +1,7 @@
 package keepersecurity.run
 
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
@@ -12,6 +13,9 @@ import keepersecurity.util.KeeperCommandUtils
 import keepersecurity.util.KeeperJsonUtils
 import keepersecurity.util.KeeperRecordFieldExtractor
 import java.io.File
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 /**
  * Shared pipeline: read `.env` Keeper refs, fetch secrets via shell, run a command with injected env.
@@ -25,6 +29,13 @@ object KeeperSecureScriptRunner {
         isLenient = true
         allowTrailingComma = true
     }
+
+    /** Hard ceiling on a single Run Keeper Securely invocation; the Stop button kicks in earlier. */
+    private const val SCRIPT_HARD_TIMEOUT_SECONDS: Long = 24L * 60L * 60L
+
+    /** Maximum time to wait for the persistent shell prompt to appear after startShell(). */
+    private const val SHELL_READY_POLL_TIMEOUT_MS: Long = 30_000L
+    private const val SHELL_READY_POLL_INTERVAL_MS: Long = 200L
 
     data class ExecutionResult(
         val replacements: Int,
@@ -40,6 +51,7 @@ object KeeperSecureScriptRunner {
         commandLine: String,
         indicator: ProgressIndicator,
         logger: Logger,
+        onProcessStarted: (Process) -> Unit = {},
     ): ExecutionResult {
         val errors = mutableListOf<String>()
         val keeperPattern = Regex("""keeper://([A-Za-z0-9_-]+)/field/(\S+)""")
@@ -81,6 +93,7 @@ object KeeperSecureScriptRunner {
         indicator.text = "Fetching ${keeperRefs.size} secrets via persistent shell..."
 
         keeperRefs.forEachIndexed { index, (key, uid, field) ->
+            if (indicator.isCanceled) throw ProcessCanceledException()
             indicator.text = "Fetching secret ${index + 1}/${keeperRefs.size}: $key"
             try {
                 val secretJson = getKeeperJsonFromShell(uid, logger)
@@ -104,8 +117,18 @@ object KeeperSecureScriptRunner {
             }
         }
 
+        if (indicator.isCanceled) throw ProcessCanceledException()
+
         indicator.text = "Running script with injected secrets..."
-        val (scriptOutput, exitCode) = runScriptWithEnv(envVars, commandLine, errors, workingDirectory, logger)
+        val (scriptOutput, exitCode) = runScriptWithEnv(
+            envVars,
+            commandLine,
+            errors,
+            workingDirectory,
+            indicator,
+            logger,
+            onProcessStarted,
+        )
         return ExecutionResult(envVars.size, errors, scriptOutput, exitCode)
     }
 
@@ -114,7 +137,9 @@ object KeeperSecureScriptRunner {
         commandLine: String,
         errors: MutableList<String>,
         fileParentDir: File,
+        indicator: ProgressIndicator,
         logger: Logger,
+        onProcessStarted: (Process) -> Unit,
     ): Pair<String, Int> {
         return try {
             if (commandLine.isBlank()) {
@@ -143,14 +168,51 @@ object KeeperSecureScriptRunner {
             logger.info("Command: ${commandParts.joinToString(" ")}")
 
             val process = pb.start()
-            val output = process.inputStream.bufferedReader().use { it.readText() }
-            val exitCode = process.waitFor()
+            onProcessStarted(process)
 
+            // Drain stdout on a separate thread so a hung child can't block cancellation behind
+            // a synchronous readText() that's waiting for an EOF that may never arrive.
+            val outputFuture = CompletableFuture.supplyAsync {
+                process.inputStream.bufferedReader().use { it.readText() }
+            }
+
+            val scriptStart = System.currentTimeMillis()
+            while (process.isAlive) {
+                if (indicator.isCanceled) {
+                    process.destroyForcibly()
+                    throw ProcessCanceledException()
+                }
+                if (System.currentTimeMillis() - scriptStart > SCRIPT_HARD_TIMEOUT_SECONDS * 1000L) {
+                    logger.warn("Script exceeded hard timeout (${SCRIPT_HARD_TIMEOUT_SECONDS}s); destroying.")
+                    process.destroyForcibly()
+                    errors.add("Command exceeded ${SCRIPT_HARD_TIMEOUT_SECONDS}s timeout and was killed")
+                    break
+                }
+                process.waitFor(1, TimeUnit.SECONDS)
+            }
+
+            // Stop both cancels the indicator and force-kills the process; if the kill races ahead
+            // of the next isCanceled check the loop exits with the SIGKILL exit code. Re-check here
+            // so user cancellation always surfaces cleanly.
+            if (indicator.isCanceled) {
+                throw ProcessCanceledException()
+            }
+
+            val output = try {
+                outputFuture.get(2, TimeUnit.SECONDS)
+            } catch (_: TimeoutException) {
+                outputFuture.cancel(true)
+                ""
+            }
+
+            val exitCode = process.exitValue()
             logger.info("Script completed with exit code: $exitCode")
             if (exitCode != 0) {
                 errors.add("Command exited with code $exitCode")
             }
             Pair(output, exitCode)
+        } catch (pce: ProcessCanceledException) {
+            throw pce
         } catch (ex: Exception) {
             logger.error("Failed to run script", ex)
             errors.add("Failed to execute script: ${ex.message}")
@@ -178,46 +240,53 @@ object KeeperSecureScriptRunner {
                     logger.error("Failed to start Keeper shell")
                     return false
                 }
-                logger.info("Shell started successfully, waiting for full initialization...")
-                Thread.sleep(5000)
+                logger.info("Shell started; polling until prompt appears...")
+                pollUntilShellPromptSeen(SHELL_READY_POLL_TIMEOUT_MS, logger)
             }
 
+            // Liveness check only. KeeperShellService.executeCommand strips the prompt strings
+            // (My Vault>, Keeper>, Not logged in>) out of its return value, so matching the response
+            // content is unreliable. KeeperShellService.isReady() is authoritative — it's set during
+            // startup once the real prompt is observed on the raw output.
             val timeoutSeconds = if (wasAlreadyReady) 15L else 45L
-            logger.info("Verifying shell readiness (timeout: ${timeoutSeconds}s)...")
-
-            val output = try {
+            logger.info("Probing shell liveness (timeout: ${timeoutSeconds}s)...")
+            try {
                 KeeperShellService.executeCommand("", timeoutSeconds)
             } catch (e: Exception) {
-                logger.warn("Empty command failed, trying 'this-device': ${e.message}")
-                KeeperShellService.executeCommand("this-device", timeoutSeconds)
+                logger.warn("Shell liveness probe failed: ${e.message}")
+                return false
             }
-
-            val isReady = output.contains("My Vault>", ignoreCase = true) ||
-                output.contains("Keeper>", ignoreCase = true) ||
-                output.contains("Not logged in>", ignoreCase = true) ||
-                output.contains("Persistent Login: ON", ignoreCase = true) ||
-                output.contains("Status: SUCCESSFUL", ignoreCase = true) ||
-                output.contains("Device Name:", ignoreCase = true) ||
-                output.contains("Decrypted [", ignoreCase = true) ||
-                output.contains("record(s)", ignoreCase = true) ||
-                (output.isNotBlank() && !output.contains("error", ignoreCase = true) && !output.contains("failed", ignoreCase = true))
-
-            if (!isReady) {
-                try {
-                    val testOutput = KeeperShellService.executeCommand("", 10)
-                    if (testOutput.contains(">") || testOutput.isBlank()) {
-                        return true
-                    }
-                } catch (e: Exception) {
-                    logger.warn("Final test failed: ${e.message}")
-                }
-            }
-
-            isReady
+            KeeperShellService.isReady()
         } catch (ex: Exception) {
             logger.error("Error checking Keeper readiness: ${ex.message}")
             logger.debug("Full exception details", ex)
             false
         }
+    }
+
+    /**
+     * Polls [KeeperShellService.getLastStartupOutput] for one of the known prompt strings;
+     * returns as soon as the prompt is seen, or when [maxWaitMs] elapses.
+     */
+    private fun pollUntilShellPromptSeen(maxWaitMs: Long, logger: Logger): Boolean {
+        val start = System.currentTimeMillis()
+        while (System.currentTimeMillis() - start < maxWaitMs) {
+            val out = KeeperShellService.getLastStartupOutput()
+            if (out.contains("My Vault>") ||
+                out.contains("Keeper>") ||
+                out.contains("Not logged in>")
+            ) {
+                logger.info("Shell prompt detected after ${System.currentTimeMillis() - start}ms")
+                return true
+            }
+            try {
+                Thread.sleep(SHELL_READY_POLL_INTERVAL_MS)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                return false
+            }
+        }
+        logger.warn("Shell prompt not seen within ${maxWaitMs}ms")
+        return false
     }
 }

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
@@ -31,11 +31,7 @@ object KeeperSecureScriptRunner {
     }
 
     /** Hard ceiling on a single Run Keeper Securely invocation; the Stop button kicks in earlier. */
-    private const val SCRIPT_HARD_TIMEOUT_SECONDS: Long = 24L * 60L * 60L
-
-    /** Maximum time to wait for the persistent shell prompt to appear after startShell(). */
-    private const val SHELL_READY_POLL_TIMEOUT_MS: Long = 30_000L
-    private const val SHELL_READY_POLL_INTERVAL_MS: Long = 200L
+    private const val SCRIPT_HARD_TIMEOUT_SECONDS: Long = 60L * 60L
 
     data class ExecutionResult(
         val replacements: Int,
@@ -80,6 +76,7 @@ object KeeperSecureScriptRunner {
         }
 
         if (!isKeeperReady(logger)) {
+            if (indicator.isCanceled) throw ProcessCanceledException()
             return ExecutionResult(
                 0,
                 listOf("Keeper is not ready. Run 'Check Keeper Authorization' first."),
@@ -87,6 +84,7 @@ object KeeperSecureScriptRunner {
                 -1,
             )
         }
+        if (indicator.isCanceled) throw ProcessCanceledException()
 
         val envVars = mutableMapOf<String, String>()
         logger.info("Found ${keeperRefs.size} Keeper references to process")
@@ -240,8 +238,6 @@ object KeeperSecureScriptRunner {
                     logger.error("Failed to start Keeper shell")
                     return false
                 }
-                logger.info("Shell started; polling until prompt appears...")
-                pollUntilShellPromptSeen(SHELL_READY_POLL_TIMEOUT_MS, logger)
             }
 
             // Liveness check only. KeeperShellService.executeCommand strips the prompt strings
@@ -262,31 +258,5 @@ object KeeperSecureScriptRunner {
             logger.debug("Full exception details", ex)
             false
         }
-    }
-
-    /**
-     * Polls [KeeperShellService.getLastStartupOutput] for one of the known prompt strings;
-     * returns as soon as the prompt is seen, or when [maxWaitMs] elapses.
-     */
-    private fun pollUntilShellPromptSeen(maxWaitMs: Long, logger: Logger): Boolean {
-        val start = System.currentTimeMillis()
-        while (System.currentTimeMillis() - start < maxWaitMs) {
-            val out = KeeperShellService.getLastStartupOutput()
-            if (out.contains("My Vault>") ||
-                out.contains("Keeper>") ||
-                out.contains("Not logged in>")
-            ) {
-                logger.info("Shell prompt detected after ${System.currentTimeMillis() - start}ms")
-                return true
-            }
-            try {
-                Thread.sleep(SHELL_READY_POLL_INTERVAL_MS)
-            } catch (_: InterruptedException) {
-                Thread.currentThread().interrupt()
-                return false
-            }
-        }
-        logger.warn("Shell prompt not seen within ${maxWaitMs}ms")
-        return false
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #12. Addresses all 14 review comments left after merge,
plus the publishing-blocker placeholder URL and `[Unreleased]` changelog
entry.

## Changes by review comment

| Area | File | Change |
|---|---|---|
| HTTP variable resolution | `KeeperHttpSecretResolver.kt` | Throw on missing field and on caught exceptions so the HTTP Client surfaces a variable-resolution error instead of substituting the message into the request |
| Run config Stop button | `KeeperSecureProcessHandler.kt` | `destroyProcessImpl` cancels the indicator and force-kills the spawned process via `@Volatile` references; emits `Cancelled by user` on user-initiated stop |
| Cancellation in secret fetch | `KeeperSecureScriptRunner.kt` | `if (indicator.isCanceled) throw ProcessCanceledException()` at the top of each iteration |
| Process timeout / hangs | `KeeperSecureScriptRunner.kt` | Stdout drained on a separate thread; main loop polls `process.isAlive` with a 1s waitFor and a 24h hard ceiling; `destroyForcibly()` on cancel or timeout |
| Onboarding sleep | `KeeperSecureScriptRunner.kt` | Removed `Thread.sleep(5000)` after `startShell()`; replaced with a 200ms-interval poll on `KeeperShellService.getLastStartupOutput` capped at 30s |
| Readiness check | `KeeperSecureScriptRunner.kt` | Removed the negative-only `isNotBlank() && !error && !failed` fallback; switched to a liveness probe plus `KeeperShellService.isReady()` |
| Run config defaults | `KeeperSecureRunConfigurationType.kt` | Removed the duplicate `applyDefaults` in `configureDefaultSettings`; `onNewConfigurationCreated()` is now the single entry point |
| Editor blank handling | `KeeperSecureRunConfigurationEditor.kt` | Removed the silent `ifBlank { ".env" }` in `applyEditorTo` and `resetEditorFrom`; `checkConfiguration` is the single place that errors on blank input |
| File type detection | `KeeperGetSecretAction.kt` | Compares `file.fileType` against `HttpRequestFileType.INSTANCE`, guarded by a `com.jetbrains.restClient` enabled-plugin check; works with custom associations and scratch files |
| Snippet messaging | `KeeperGetSecretAction.kt` | `buildInsertionSuccessMessage` takes an explicit Boolean instead of regex-matching the inserted text |
| Release | `CHANGELOG.md`, `gradle.properties` | Pin to `1.1.0 - 2026-05-07`; replace the placeholder `pluginRepositoryUrl` with `https://github.com/Keeper-Security/keeper-jetbrains-plugin` |

## Deviations from the literal review wording

Two items were addressed but with adjustments from the exact suggestion;
both are intentional and documented in code:

- **`startNotify` lifecycle:** Kept the secret-fetch + spawn flow inside
  `startNotify` and wired Stop through `@Volatile` `Process` and
  `ProgressIndicator` references rather than starting the user process
  before `startNotify`. Doing the strict reorder would require running
  the secret fetch synchronously in `RunProfileState.execute()` and
  blocking the EDT.
- **Positive prompt matching for readiness:** The literal change broke
  authenticated shells because `KeeperShellService.executeCommand`
  filters `My Vault>`, `Keeper>`, and `Not logged in>` lines out of the
  response before returning, so positive content matching could never
  succeed. Replaced with a liveness probe plus `KeeperShellService.isReady()`,
  which is set during startup once a real prompt is observed on the
  raw output. The negative-only fallback that motivated the comment is
  gone.

Happy to do a follow-up PR for the strict implementations of either if
preferred.

## Test plan

Manually verified in the sandbox IDE (`./gradlew runIde`, IU 2024.3.6)
against the `JetBrainsDemo` project:

- [x] Run config `StopTest` (long-running script) — Stop terminates the
      process within ~1 s; output ends with `Cancelled by user` and
      exit code `-1`. No leftover processes (`ps -ef | grep long_run`).
- [x] Run config with multi-ref `.env` — Stop during the
      `Fetching secret N/5` phase aborts within ~1 s; user command never
      starts (no `Tick N` output).
- [x] Authenticated shell flow — secrets are fetched and injected, no
      spurious `Keeper is not ready` rejection.
- [x] `./gradlew compileKotlin compileJava` clean.