### PR TITLE
feat: Nested Shared Folder support, picker badges, and Run Securely hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+- **Nested Shared Folder support** across *Get Keeper Folder*, *Get Keeper Secret*, *Add Keeper Record*, *Update Keeper Record*, and *Generate Keeper Secret*. The plugin routes to Classic (`record-*`) or Nested Shared (`nsf-*`) commands based on vault metadata.
+- **Searchable folder and record picker** with **Classic** / **Nested** badges on each row.
+
+### Changed
+- **Get Keeper Folder** and **Get Keeper Secret** now include Nested Shared folders and records alongside Classic ones.
+- **Update Keeper Record** validates the record UID and chooses `record-update` vs `nsf-record-update` automatically.
+- **Run Keeper Securely** validates `keeper://` record UIDs and hardens environment injection from resolved secrets.
+
+### Fixed
+- **Commander compatibility** for current folder and record discriminators (`classic_folder` / `nested_share_folder`, `Classic` / `Nested`), with support for older wire values.
+
 ## [1.2.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Keeper Security JetBrains Plugin
 
 <!-- Plugin description -->
-A comprehensive JetBrains IDE plugin that integrates Keeper Security vault functionality directly into your development workflow. Use Keeper references in `.env` files and in **JetBrains HTTP Client** (`.http` files) where supported, save **Run Keeper Securely** run configurations, and use Tools-menu actions to manage secrets without pasting plaintext into your project.
+A comprehensive JetBrains IDE plugin that integrates Keeper Security vault functionality directly into your development workflow. Supports **Classic** and **Nested Shared Folder** vault items in the same actions. Use Keeper references in `.env` files and in **JetBrains HTTP Client** (`.http` files) where supported, save **Run Keeper Securely** run configurations, and use Tools-menu actions to manage secrets without pasting plaintext into your project.
 
 The goal is to enable developers to manage secrets securely without leaving their development environment, while maintaining the highest security standards and providing seamless integration with existing Keeper Security infrastructure.
 
@@ -23,7 +23,7 @@ The goal is to enable developers to manage secrets securely without leaving thei
 
 ## Overview
 
-A comprehensive JetBrains IDE plugin that integrates Keeper Security vault functionality directly into your development workflow: secret references in `.env` and **HTTP Client** requests, **Run Keeper Securely** from the Tools menu or as a saved run configuration, and vault actions from the editor.
+A comprehensive JetBrains IDE plugin that integrates Keeper Security vault functionality directly into your development workflow: secret references in `.env` and **HTTP Client** requests, **Run Keeper Securely** from the Tools menu or as a saved run configuration, and vault actions for **Classic** and **Nested Shared Folder** items from the editor.
 
 The goal is to enable developers to manage secrets securely without leaving their development environment, while maintaining the highest security standards and providing seamless integration with existing Keeper Security infrastructure.
 
@@ -36,7 +36,8 @@ The goal is to enable developers to manage secrets securely without leaving thei
 - **JetBrains HTTP Client** (optional): Reference vault values in `.http` files via the `$keeper(...)` dynamic variable where the HTTP Client plugin is bundled (e.g. IntelliJ IDEA Ultimate)
 - **Run configurations**: Save a **Run Keeper Securely** configuration (`.env` path, working directory, command) under **Run → Edit Configurations** with output in the Run tool window
 - **Fast Performance**: Uses persistent Keeper shell for blazing-fast secret operations
-- **Folder Management**: Select and manage Keeper vault folders for organized secret storage
+- **Nested Shared Folders**: Classic and Nested Shared folders and records in the same actions; automatic routing to `record-*` or `nsf-*` Commander commands
+- **Folder Management**: Select Classic or Nested Shared folders for organized secret storage
 - **Record Operations**: Create new records, update existing ones, and retrieve field references
 - **Comprehensive Logging**: Built-in logging system with detailed operation tracking
 - **Retry Logic**: Robust error handling with automatic retry for shell startup timing
@@ -46,6 +47,7 @@ The goal is to enable developers to manage secrets securely without leaving thei
 - **Keeper Commander CLI**: Must be installed and authenticated on your system
   - Download from [Keeper Commander Installation Guide](https://docs.keeper.io/commander/)
   - Authenticate using persistent login or biometric login
+  - **Nested Shared Folder** create/update flows need a recent Commander with `nsf-*` commands ([CLI reference](https://docs.keeper.io/keeperpam/commander-cli/command-reference/nested-shared-folder)). Run `pip install --upgrade keepercommander` if you see unknown `nsf-record-add` errors.
 - **Keeper Security Account**: Active subscription with vault access
 - **System Requirements**:
   - JetBrains IDE: **2024.3 or later** (`pluginSinceBuild = 243`)
@@ -89,11 +91,11 @@ All Keeper actions are available through two locations:
 | Action | Description | Use Case |
 |--------|-------------|----------|
 | Check Keeper Authorization | Verify Keeper CLI installation and authentication | Troubleshoot connection issues |
-| Get Keeper Secret | Insert existing secrets from vault as references | Retrieve stored secrets without exposing values |
+| Get Keeper Secret | Insert existing secrets (Classic or Nested Shared) as references | Retrieve stored secrets without exposing values |
 | Add Keeper Record | Create new vault record from selected text | Replace hardcoded secrets with vault references |
-| Update Keeper Record | Update existing vault record and replace text | Modify existing secret values |
+| Update Keeper Record | Update existing record by UID and replace text | Modify existing secret values |
 | Generate Keeper Secret | Generate secure passwords and store in vault | Create new secure credentials |
-| Get Keeper Folder | Select vault folder for organized storage | Choose storage location for new records |
+| Get Keeper Folder | Select Classic or Nested Shared folder for this project | Choose storage location for new records |
 | Run Keeper Securely | Run a command with secrets from `.env` (Tools menu or saved run configuration) | Run applications or scripts with vault-backed env vars |
 
 ### Command Details
@@ -113,8 +115,8 @@ All Keeper actions are available through two locations:
 **Steps**:
 1. Position cursor where you want to insert the secret reference (including inside a `.http` file, when using HTTP Client)
 2. Right-click → `Get Keeper Secret` or `Tools → Keeper Vault → Get Keeper Secret`
-3. Plugin shows list of available vault records
-4. Select the specific record you want to use
+3. Plugin shows a searchable list of vault records (Classic and Nested Shared), each with a **Classic** or **Nested** badge
+4. Select the record you want to use
 5. Choose the field from that record
 6. Plugin inserts the appropriate reference at the cursor (e.g. `keeper://…` in `.env`/code, or an HTTP Client snippet in `.http` files where supported)
 
@@ -135,10 +137,10 @@ database_password = keeper://abc123def456/field/password
 **Steps**:
 1. Select text containing a secret (password, token, API key, etc.)
 2. Right-click → `Add Keeper Record` or `Tools → Keeper Vault → Add Keeper Record`
-3. Enter record title when prompted
-4. Enter field name for the secret
-5. Plugin creates new vault record
-6. Selected text is replaced with secret reference
+3. Run **Get Keeper Folder** first if you want new records in a specific Classic or Nested Shared folder (otherwise the vault root is used)
+4. Enter record title when prompted
+5. Enter field name for the secret
+6. Plugin creates the record in the correct vault (Classic or Nested Shared) and replaces the selection with a secret reference
 
 **Example**:
 ```javascript
@@ -153,12 +155,11 @@ const apiKey = keeper://new-record-uid/field/api_key;
 **Purpose**: Update an existing Keeper record with new secret value and replace selected text with reference.
 
 **Steps**:
-1. Select text containing the updated secret value
+1. Select text containing the updated secret value (or place the caret on the value after `=`)
 2. Right-click → `Update Keeper Record`
-3. Choose existing record from the list
-4. Select field to update
-5. Plugin updates the vault record
-6. Selected text is replaced with reference
+3. Enter the Keeper **record UID** when prompted
+4. Enter the **field name** to update
+5. Plugin validates the UID, updates the record in the correct vault (Classic or Nested Shared), and replaces the selection with a `keeper://` reference
 
 #### Generate Keeper Secret
 **Purpose**: Generate secure passwords and store them in Keeper Security vault.
@@ -166,9 +167,9 @@ const apiKey = keeper://new-record-uid/field/api_key;
 **Steps**:
 1. Position cursor where you want the secret reference
 2. Right-click → `Generate Keeper Secret`
-3. Enter record title and field name
-4. Plugin generates secure password and stores it in vault
-5. Secret reference is inserted at cursor position
+3. Run **Get Keeper Folder** first if you want the new record in a specific Classic or Nested Shared folder
+4. Enter record title and field name when prompted
+5. Plugin generates a secure password, stores it in the correct vault, and inserts a secret reference at the cursor
 
 **Example**:
 ```yaml
@@ -180,13 +181,12 @@ admin_password: keeper://generated-record-uid/field/password
 ```
 
 #### Get Keeper Folder
-**Purpose**: Select the vault folder where new secrets will be stored for this project.
+**Purpose**: Select a Classic or Nested Shared folder for this project (used by **Add Keeper Record** and **Generate Keeper Secret**).
 
 **Steps**:
 1. Go to `Tools → Keeper Vault → Get Keeper Folder`
-2. Plugin displays available vault folders
-3. Select desired folder for this workspace
-4. Future `Add Keeper Record` and `Generate Keeper Secret` operations will use this folder
+2. Search and pick a folder; each row shows a **Classic** or **Nested** badge
+3. The selection is saved for this project; add and generate actions use the matching Commander command family (`record-*` or `nsf-*`)
 
 #### Run Keeper Securely
 **Purpose**: Run commands with secrets injected from Keeper Security vault through `.env` file processing (`keeper://…` references are resolved at run time).
@@ -212,6 +212,8 @@ DATABASE_URL=keeper://db-record-uid/field/connection_string
 API_KEY=keeper://api-record-uid/field/key
 SECRET_KEY=keeper://app-record-uid/field/secret
 ```
+
+Record UIDs in `keeper://` references must be valid Keeper record UIDs (22 URL-safe Base64 characters: `A-Z`, `a-z`, `0-9`, `_`, `-`). Invalid UIDs are skipped with an error message.
 
 **Command execution** (conceptually):
 ```bash
@@ -298,7 +300,7 @@ If you encounter issues, enable detailed logging:
 **Problem**: Commands don't have access to injected secrets or fail to execute
 
 **Solutions**:
-- Verify your `.env` file contains valid `keeper://` references
+- Verify your `.env` file contains valid `keeper://` references with 22-character record UIDs
 - Ensure all referenced secrets exist in your vault
 - For **Run → Run Keeper Securely**, confirm paths and working directory in **Edit Configurations**
 - For the **Tools** menu flow, check the result dialog and logs if the command fails

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -193,6 +193,15 @@ tasks.test {
     include("**/KeeperRecordUpdateActionTest*")
     include("**/KeeperSecretActionTest*")
     include("**/KeeperAuthActionTest*")
+    // Nested Shared Folders coverage (those flows are folded into the unified
+    // KeeperFolderSelectAction / KeeperGetSecretAction tests above; the
+    // shared validator + target-prompt suites are independent and stay).
+    include("**/KeeperRecordOutputValidatorsTest*")
+    include("**/KeeperRecordTargetPromptTest*")
+    include("**/KeeperFolderValidatorTest*")
+    include("**/KeeperRecordValidatorTest*")
+    include("**/KeeperCliSafetyTest*")
+    include("**/KeeperEnvSafetyTest*")
 }
 
 intellijPlatformTesting {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginGroup = com.keepersecurity.jetbrains
 pluginName = Keeper Security
 pluginRepositoryUrl = https://github.com/Keeper-Security/keeper-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.2.0
+pluginVersion = 2.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243

--- a/src/main/kotlin/keepersecurity/action/KeeperAuthAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperAuthAction.kt
@@ -12,6 +12,20 @@ import keepersecurity.service.KeeperShellService
 import java.util.concurrent.TimeUnit
 
 /**
+ * Three-state outcome of the Keeper shell probe used by [KeeperAuthAction].
+ *
+ *  - [AUTHENTICATED] — shell is up *and* the user is logged in. Safe to
+ *    proceed with any other Keeper action.
+ *  - [NOT_LOGGED_IN] — shell process exists, but Commander reports the
+ *    "Not logged in>" prompt. The user must run `keeper login` once.
+ *  - [FAILED] — shell did not respond, returned blank output, or otherwise
+ *    failed to demonstrate a working authenticated session. We refuse to
+ *    declare success on weak evidence (older code's catch-all rule led to
+ *    false-positive "Authorization OK" dialogs against a half-dead shell).
+ */
+private enum class ProbeResult { AUTHENTICATED, NOT_LOGGED_IN, FAILED }
+
+/**
  * Action to check and diagnose Keeper authentication status
  */
 class KeeperAuthAction : AnAction("Check Keeper Authorization") {
@@ -32,17 +46,62 @@ class KeeperAuthAction : AnAction("Check Keeper Authorization") {
                     val wasReady = KeeperShellService.isReady()
                     val started = if (!wasReady) KeeperShellService.startShell() else true
                     if (!started) {
-                        ApplicationManager.getApplication().invokeLater {
-                            Messages.showErrorDialog(
-                                project,
-                                "Failed to start Keeper shell.\nPlease check that Keeper CLI is installed and you're authenticated.",
-                                "Authorization Failed"
+                        // Differentiate "Commander is asking for a master password
+                        // and we can't supply one over pipes" from "the CLI is
+                        // missing / crashed". The former is the common case after
+                        // `keeper logout` and the user just needs to refresh their
+                        // persistent-login token once in a real terminal.
+                        val (title, msg) = if (KeeperShellService.isAuthRequired()) {
+                            "Not Logged In to Keeper" to (
+                                "Keeper Commander is asking for a master password, " +
+                                "but the plugin can't supply one over a piped shell.\n\n" +
+                                "Open a terminal and run:\n" +
+                                "    keeper login --persistent\n\n" +
+                                "Once you're logged in there (and Persistent Login is " +
+                                "enabled on your account), come back and try this action again."
                             )
+                        } else {
+                            "Authorization Failed" to (
+                                "Failed to start Keeper shell.\n" +
+                                "Please check that Keeper CLI is installed and you're authenticated."
+                            )
+                        }
+                        ApplicationManager.getApplication().invokeLater {
+                            Messages.showErrorDialog(project, msg, title)
                         }
                         return
                     }
 
-                    fun probe(timeout: Long): Pair<Boolean, String> {
+                    /**
+                     * Classify the probe output. Important: by the time the
+                     * output reaches us, [KeeperShellService.executeCommand]
+                     * has already filtered out the literal prompt strings
+                     * (`My Vault>`, `Keeper>`, `Not logged in>`) — see the
+                     * stripper at `KeeperShellService.kt#L678/685`. So we
+                     * can't rely on prompts as positive markers; we look at
+                     * the surrounding banner text instead.
+                     *
+                     * Positive evidence of an authenticated session (any of
+                     * these only appear *after* Commander successfully
+                     * authenticates and starts syncing):
+                     *   - "Decrypted N records" / "Updated security data"
+                     *   - "Quick Start:" help banner
+                     *   - "breachwatch" / "high-risk passwords" warnings
+                     *   - "Successfully authenticated" /
+                     *     "Status: SUCCESSFUL" / "Device Name:" /
+                     *     "Persistent Login: ON"
+                     *
+                     * Negative evidence — Commander text emitted *before* the
+                     * stripped "Not logged in>" prompt:
+                     *   - "you are not logged in"
+                     *   - "please login" / "use `login`"
+                     *
+                     * Falls back to [KeeperShellService.isReady] when the
+                     * banner text alone is inconclusive — the service flips
+                     * its ready flag only after observing a real prompt on
+                     * the raw stream, so it's the most trustworthy signal.
+                     */
+                    fun probe(timeout: Long): Pair<ProbeResult, String> {
                         val output = try {
                             try {
                                 KeeperShellService.executeCommand("", timeout)
@@ -50,46 +109,85 @@ class KeeperAuthAction : AnAction("Check Keeper Authorization") {
                                 KeeperShellService.executeCommand("this-device", timeout)
                             }
                         } catch (e: Exception) {
-                            return false to "Probe failed: ${e.message ?: "Unknown error"}"
+                            return ProbeResult.FAILED to "Probe failed: ${e.message ?: "Unknown error"}"
                         }
-                        val ok = output.contains("My Vault>", true) ||
-                                 output.contains("Keeper>", true) ||
-                                 output.contains("Status: SUCCESSFUL", true) ||
-                                 output.contains("Device Name:", true) ||
-                                 output.contains("Persistent Login: ON", true) ||
-                                 output.contains("record(s)", true) ||
-                                 (output.isNotBlank() && !output.contains("error", true) && !output.contains("failed", true))
-                        return ok to output
+
+                        val notLoggedIn = output.contains("you are not logged in", true) ||
+                            output.contains("please login", true) ||
+                            output.contains("not authenticated", true) ||
+                            output.contains("use `login`", true) ||
+                            output.contains("use 'login'", true)
+
+                        val authMarkers = listOf(
+                            // Post-login sync / decrypt banner
+                            "Decrypted",
+                            "Updated security data",
+                            "high-risk passwords",
+                            "breachwatch list",
+                            // Post-login help banner (Commander v18+)
+                            "Quick Start:",
+                            // `this-device` / login-status output
+                            "Status: SUCCESSFUL",
+                            "Device Name:",
+                            "Persistent Login: ON",
+                            "Successfully authenticated"
+                        )
+                        val authenticated = authMarkers.any { output.contains(it, ignoreCase = true) }
+
+                        return when {
+                            authenticated && !notLoggedIn -> ProbeResult.AUTHENTICATED to output
+                            notLoggedIn -> ProbeResult.NOT_LOGGED_IN to output
+                            // Last resort: the persistent shell flips its
+                            // ready flag only after seeing a real
+                            // authenticated prompt on the raw stream. Trust
+                            // that over an inconclusive stripped-output
+                            // sample.
+                            KeeperShellService.isReady() -> ProbeResult.AUTHENTICATED to output
+                            else -> ProbeResult.FAILED to output
+                        }
                     }
 
-                    val (ok, out) = probe(if (wasReady) 15 else 45)
-                    if (ok) {
-                        val msg = if (out.contains("Successfully authenticated with Biometric Login", true)) {
-                            "Keeper shell is ready. Authentication passed using biometric."
-                        } else if (out.contains("Not logged in>", true)) {
-                            "Keeper shell is ready but not authenticated.\nPlease run 'keeper login' once to establish a persistent session."
-                        } else {
-                            "Keeper shell is ready."
-                        }
-                        ApplicationManager.getApplication().invokeLater {
-                            Messages.showInfoMessage(project, msg, "Authorization Check")
-                        }
-                        return
-                    }
-
-                    // Last fallback: gentle newline probe then report as before...
-                    try {
-                        val finalOut = KeeperShellService.executeCommand("", 10)
-                        ApplicationManager.getApplication().invokeLater {
-                            if (finalOut.contains(">") || finalOut.isBlank()) {
-                                Messages.showInfoMessage(project, "Keeper shell is responding. Authorization likely OK.", "Authorization Check")
+                    val (result, out) = probe(if (wasReady) 15 else 45)
+                    when (result) {
+                        ProbeResult.AUTHENTICATED -> {
+                            val msg = if (out.contains("Successfully authenticated with Biometric Login", true)) {
+                                "Keeper shell is ready. Authentication passed using biometric."
                             } else {
-                                Messages.showErrorDialog(project, "Keeper shell did not report ready.\n$finalOut", "Authorization Possibly Not Ready")
+                                "Keeper shell is ready and authenticated."
+                            }
+                            ApplicationManager.getApplication().invokeLater {
+                                Messages.showInfoMessage(project, msg, "Authorization Check")
                             }
                         }
-                    } catch (_: Exception) {
-                        ApplicationManager.getApplication().invokeLater {
-                            Messages.showErrorDialog(project, "Unable to verify Keeper shell readiness.", "Authorization Failed")
+                        ProbeResult.NOT_LOGGED_IN -> {
+                            // Not an OK state — surface as an error so the
+                            // user doesn't mistake the info icon for success.
+                            ApplicationManager.getApplication().invokeLater {
+                                Messages.showErrorDialog(
+                                    project,
+                                    "Keeper shell is running but you are not logged in.\n\n" +
+                                        "Please run `keeper login` in a terminal once to establish a " +
+                                        "persistent session, then try this action again.",
+                                    "Not Logged In to Keeper"
+                                )
+                            }
+                        }
+                        ProbeResult.FAILED -> {
+                            // Don't paper over a half-dead shell as "likely
+                            // OK". The user's own commands will fail next;
+                            // it's better to flag it up front.
+                            val detail = if (out.isBlank()) {
+                                "The shell did not produce any output within the probe timeout."
+                            } else {
+                                "Output:\n${out.take(500)}"
+                            }
+                            ApplicationManager.getApplication().invokeLater {
+                                Messages.showErrorDialog(
+                                    project,
+                                    "Keeper shell did not report a logged-in state.\n\n$detail",
+                                    "Authorization Not Confirmed"
+                                )
+                            }
                         }
                     }
                     

--- a/src/main/kotlin/keepersecurity/action/KeeperAuthAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperAuthAction.kt
@@ -14,11 +14,11 @@ import java.util.concurrent.TimeUnit
 /**
  * Three-state outcome of the Keeper shell probe used by [KeeperAuthAction].
  *
- *  - [AUTHENTICATED] — shell is up *and* the user is logged in. Safe to
+ *  - `AUTHENTICATED` — shell is up *and* the user is logged in. Safe to
  *    proceed with any other Keeper action.
- *  - [NOT_LOGGED_IN] — shell process exists, but Commander reports the
+ *  - `NOT_LOGGED_IN` — shell process exists, but Commander reports the
  *    "Not logged in>" prompt. The user must run `keeper login` once.
- *  - [FAILED] — shell did not respond, returned blank output, or otherwise
+ *  - `FAILED` — shell did not respond, returned blank output, or otherwise
  *    failed to demonstrate a working authenticated session. We refuse to
  *    declare success on weak evidence (older code's catch-all rule led to
  *    false-positive "Authorization OK" dialogs against a half-dead shell).

--- a/src/main/kotlin/keepersecurity/action/KeeperFolderSelectAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperFolderSelectAction.kt
@@ -57,6 +57,7 @@ class KeeperFolderSelectAction : AnAction("Get Keeper Folder") {
         fun toPickerItem() = KeeperListPickerItem(
             label = name,
             badge = if (isDrive) KeeperVaultBadge.NESTED else KeeperVaultBadge.CLASSIC,
+            id = uid,
         )
     }
 
@@ -105,8 +106,9 @@ class KeeperFolderSelectAction : AnAction("Get Keeper Folder") {
                         initialSelection = pickerItems.firstOrNull()
                     ) ?: return@invokeLater
 
-                    val selectedFolder = folderChoices.find { it.name == selected.label && it.isDrive == (selected.badge == KeeperVaultBadge.NESTED) }
-                        ?: folderChoices.find { it.toPickerItem() == selected }
+                    val selectedFolder = selected.id?.let { uid ->
+                        folderChoices.find { it.uid == uid }
+                    }
                     if (selectedFolder != null) {
                         persistFolderSelection(project, selectedFolder)
 

--- a/src/main/kotlin/keepersecurity/action/KeeperFolderSelectAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperFolderSelectAction.kt
@@ -8,80 +8,145 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.diagnostic.thisLogger
-import keepersecurity.service.KeeperShellService
+import keepersecurity.ui.KeeperListPickerDialog
+import keepersecurity.ui.KeeperListPickerItem
+import keepersecurity.ui.KeeperVaultBadge
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import keepersecurity.model.KeeperFolder
 import keepersecurity.util.KeeperJsonUtils
 import keepersecurity.util.KeeperCommandUtils
 import kotlinx.serialization.ExperimentalSerializationApi
 
+/**
+ * Unified folder picker. Shows every folder returned by Commander's
+ * `ls --format=json -f -R` — Classic folders and Nested Shared Folders
+ * — in a single dialog. Each row shows the folder name with a Classic or
+ * Nested badge so users can distinguish same-named folders across vault models.
+ *
+ * Keeper's two vault models (Classic and Nested Shared Folders) each
+ * support folders and records with their own CLI command families (`record-*`
+ * vs `nsf-*`). The picked folder is persisted into the **target-specific**
+ * preference pair so downstream record actions (`Add`, `Update`, `Generate`)
+ * route to the right CLI command:
+ *
+ *  - Nested Shared Folder → [KeeperRecordTargetPrompt.PREF_DRIVE_FOLDER_UUID]
+ *    / `_NAME`. The Classic pair is cleared on the way through so a stale
+ *    Classic UUID from a previous pick can't be reused by the Classic
+ *    target.
+ *  - Classic folder → [KeeperRecordTargetPrompt.PREF_CLASSIC_FOLDER_UUID]
+ *    / `_NAME`. The Nested Shared Folder pair is cleared symmetrically.
+ *
+ * Commander's `ls --format=json -f -R` includes both vault types in one
+ * payload, so a single picker covers Classic and Nested Shared Folder without a
+ * second menu item.
+ */
 @OptIn(ExperimentalSerializationApi::class)
 class KeeperFolderSelectAction : AnAction("Get Keeper Folder") {
     private val logger = thisLogger()
+
+    /**
+     * Internal tuple used while building the picker. Carries the raw folder
+     * name, the folder UID, and whether the folder lives in a Nested Shared
+     * Subfolder.
+     */
+    private data class FolderChoice(
+        val name: String,
+        val uid: String,
+        val isDrive: Boolean,
+    ) {
+        fun toPickerItem() = KeeperListPickerItem(
+            label = name,
+            badge = if (isDrive) KeeperVaultBadge.NESTED else KeeperVaultBadge.CLASSIC,
+        )
+    }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project: Project = e.project ?: return
 
         object : Task.Backgroundable(project, "Fetching Keeper Folders...", false) {
             override fun run(indicator: ProgressIndicator) {
-                
-                
-                val folderMap: List<Pair<String, String>> = try {
-                    // This should be FAST after the first call!
+
+                val folderChoices: List<FolderChoice> = try {
                     val startTime = System.currentTimeMillis()
-                    
-                    // Add retry logic for the first run
+
+                    indicator.text = "Syncing with Keeper vault..."
+                    KeeperCommandUtils.syncDownBestEffort(logger)
+
+                    indicator.text = "Fetching Keeper folders..."
                     val output = KeeperCommandUtils.executeCommandWithRetry(
                         "ls --format=json -f -R",
                         KeeperCommandUtils.Presets.jsonArray(maxRetries = 3, timeoutSeconds = 90),
                         logger
                     )
-                    
+
                     val duration = System.currentTimeMillis() - startTime
                     logger.info("Command executed in ${duration}ms")
-                    
+
                     parseKeeperFolders(output)
-                    
+
                 } catch (ex: Exception) {
                     logger.error("Failed to get folders from persistent shell", ex)
                     showError(project, "Failed to retrieve Keeper folders: ${ex.message}")
                     return
                 }
 
-                if (folderMap.isEmpty()) {
+                if (folderChoices.isEmpty()) {
                     showError(project, "No folders found in Keeper vault.")
                     return
                 }
 
-                // UI code remains the same
                 com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
-                    val folderNames = folderMap.map { it.first }.toTypedArray()
-                    val selected = Messages.showEditableChooseDialog(
-                        "Select a Keeper Folder:",
-                        "Keeper Folder Selection",
-                        null,
-                        folderNames,
-                        folderNames.firstOrNull(),
-                        null
+                    val pickerItems = folderChoices.map { it.toPickerItem() }
+                    val selected = KeeperListPickerDialog.pickItem(
+                        project = project,
+                        title = "Keeper Folder Selection",
+                        message = "Select a Keeper folder (Classic or Nested Shared Folder):",
+                        options = pickerItems,
+                        initialSelection = pickerItems.firstOrNull()
                     ) ?: return@invokeLater
 
-                    val selectedFolder = folderMap.find { it.first == selected }
+                    val selectedFolder = folderChoices.find { it.name == selected.label && it.isDrive == (selected.badge == KeeperVaultBadge.NESTED) }
+                        ?: folderChoices.find { it.toPickerItem() == selected }
                     if (selectedFolder != null) {
-                        val props = PropertiesComponent.getInstance(project)
-                        props.setValue("keeper.folder.name", selectedFolder.first)
-                        props.setValue("keeper.folder.uuid", selectedFolder.second)
+                        persistFolderSelection(project, selectedFolder)
 
+                        val locationLabel = if (selectedFolder.isDrive) "Nested Shared Folder" else "Classic Vault"
                         Messages.showInfoMessage(
                             project,
-                            "Folder '${selectedFolder.first}' with UUID '${selectedFolder.second}' has been saved.",
-                            "Folder Saved"
+                            "$locationLabel folder '${selectedFolder.name}' " +
+                                "(UUID '${selectedFolder.uid}') has been saved for this project.",
+                            "Keeper Folder Saved"
                         )
                     }
                 }
             }
         }.queue()
+    }
+
+    /**
+     * Persist the selection into the slot the chosen folder's vault uses,
+     * and clear the *other* slot so a stale UUID from an earlier pick (or
+     * a different account) doesn't silently leak into the wrong CLI
+     * command later. Per-project storage to match the saved-folder reads
+     * in [KeeperRecordTargetPrompt].
+     */
+    private fun persistFolderSelection(project: Project, folder: FolderChoice) {
+        val props = PropertiesComponent.getInstance(project)
+
+        if (folder.isDrive) {
+            props.setValue(KeeperRecordTargetPrompt.PREF_DRIVE_FOLDER_NAME, folder.name)
+            props.setValue(KeeperRecordTargetPrompt.PREF_DRIVE_FOLDER_UUID, folder.uid)
+            props.unsetValue(KeeperRecordTargetPrompt.PREF_CLASSIC_FOLDER_NAME)
+            props.unsetValue(KeeperRecordTargetPrompt.PREF_CLASSIC_FOLDER_UUID)
+            logger.info("Saved Nested Shared Folder '${folder.name}' (${folder.uid}); cleared classic slot")
+        } else {
+            props.setValue(KeeperRecordTargetPrompt.PREF_CLASSIC_FOLDER_NAME, folder.name)
+            props.setValue(KeeperRecordTargetPrompt.PREF_CLASSIC_FOLDER_UUID, folder.uid)
+            props.unsetValue(KeeperRecordTargetPrompt.PREF_DRIVE_FOLDER_NAME)
+            props.unsetValue(KeeperRecordTargetPrompt.PREF_DRIVE_FOLDER_UUID)
+            logger.info("Saved classic folder '${folder.name}' (${folder.uid}); cleared Nested Shared Folder slot")
+        }
     }
 
     private val json = Json {
@@ -90,27 +155,38 @@ class KeeperFolderSelectAction : AnAction("Get Keeper Folder") {
         allowTrailingComma = true
     }
 
-    private fun parseKeeperFolders(output: String): List<Pair<String, String>> {
+    /**
+     * Parse the unified `ls --format=json -f -R` output and build a picker
+     * entry per folder. Each row carries a Classic / Nested badge derived
+     * from the row's `source` discriminator. Folders without a populated
+     * `source` field default to Classic — older Commander releases predate
+     * the v3 discriminator, and the legacy `record-add --folder=<uuid>`
+     * call is the right fallback in that case.
+     */
+    private fun parseKeeperFolders(output: String): List<FolderChoice> {
         try {
             logger.debug("Raw output: ${output.take(200)}...")
-            
-            // Use the utility to extract JSON array
+
             val jsonString = KeeperJsonUtils.extractJsonArray(output, logger)
             val folders = json.decodeFromString<List<KeeperFolder>>(jsonString)
-            
-            val folderPairs = folders.mapNotNull { folder ->
-                if (folder.name.isNotBlank() && folder.folderUid.isNotBlank()) {
-                    logger.debug("Parsed folder: '${folder.name}' -> '${folder.folderUid}'")
-                    Pair(folder.name, folder.folderUid)
-                } else {
+
+            val choices = folders.mapNotNull { folder ->
+                if (folder.name.isBlank() || folder.folderUid.isBlank()) {
                     logger.debug("Skipping folder with missing data: $folder")
-                    null
+                    return@mapNotNull null
                 }
+                val isDrive = folder.isKeeperDrive
+                logger.debug("Parsed folder: '${folder.name}' -> '${folder.folderUid}' (drive=$isDrive)")
+                FolderChoice(
+                    name = folder.name,
+                    uid = folder.folderUid,
+                    isDrive = isDrive,
+                )
             }
-            
-            logger.info("Successfully parsed ${folderPairs.size} folders")
-            return folderPairs
-            
+
+            logger.info("Successfully parsed ${choices.size} folders (Nested Shared Folder: ${choices.count { it.isDrive }}, Classic: ${choices.count { !it.isDrive }})")
+            return choices
+
         } catch (ex: Exception) {
             logger.error("Failed to parse folders from output", ex)
             logger.error("Raw output was: $output")

--- a/src/main/kotlin/keepersecurity/action/KeeperFolderSelectAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperFolderSelectAction.kt
@@ -12,7 +12,6 @@ import keepersecurity.ui.KeeperListPickerDialog
 import keepersecurity.ui.KeeperListPickerItem
 import keepersecurity.ui.KeeperVaultBadge
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.decodeFromString
 import keepersecurity.model.KeeperFolder
 import keepersecurity.util.KeeperJsonUtils
 import keepersecurity.util.KeeperCommandUtils
@@ -115,7 +114,7 @@ class KeeperFolderSelectAction : AnAction("Get Keeper Folder") {
                         Messages.showInfoMessage(
                             project,
                             "$locationLabel folder '${selectedFolder.name}' " +
-                                "(UUID '${selectedFolder.uid}') has been saved for this project.",
+                                "(Uuid '${selectedFolder.uid}') has been saved for this project.",
                             "Keeper Folder Saved"
                         )
                     }

--- a/src/main/kotlin/keepersecurity/action/KeeperGenerateSecretsAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGenerateSecretsAction.kt
@@ -12,9 +12,10 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
-import com.intellij.ide.util.PropertiesComponent
+import keepersecurity.util.KeeperCliSafety
 import keepersecurity.util.KeeperCommandUtils
 import keepersecurity.util.KeeperJsonUtils
+import keepersecurity.util.KeeperRecordOutputValidators
 import kotlinx.serialization.json.Json  
 import kotlinx.serialization.decodeFromString
 import keepersecurity.model.GeneratedPassword
@@ -32,8 +33,17 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
         val selectionStart = caret.selectionStart
         val selectionEnd = caret.selectionEnd
 
+        // Ask whether the generated record should land in the Classic vault or
+        // Nested Shared Folders before collecting any more input. The dialog title
+        // matches the action label so the user knows what they're configuring.
+        val target = when (val outcome = KeeperRecordTargetPrompt.promptForGenerateTarget(project)) {
+            is KeeperRecordTargetPrompt.AddOutcome.Cancelled -> return
+            is KeeperRecordTargetPrompt.AddOutcome.Classic -> GenerateTarget.Classic(outcome.folderUuid, outcome.folderName)
+            is KeeperRecordTargetPrompt.AddOutcome.Drive -> GenerateTarget.Drive(outcome.folderUuid, outcome.folderName)
+        }
+
         // Prompt for title *on the EDT* before background work
-        val title = Messages.showInputDialog(
+        val rawTitle = Messages.showInputDialog(
             project,
             "Enter Keeper record title:",
             "Record Title",
@@ -43,14 +53,28 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
             return
         }
 
-        ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Generating Keeper Secret", false) {
+        val title = try {
+            KeeperCliSafety.requireSafe(rawTitle, "record title")
+        } catch (ex: KeeperCliSafety.UnsafeCliInputException) {
+            showError(ex.message ?: "Record title is not safe.", project)
+            return
+        }
+
+        val taskTitle = when (target) {
+            is GenerateTarget.Classic -> "Generating Keeper Secret"
+            is GenerateTarget.Drive -> "Generating Nested Shared Secret"
+        }
+
+        ProgressManager.getInstance().run(object : Task.Backgroundable(project, taskTitle, false) {
             override fun run(indicator: ProgressIndicator) {
                 try {
-                    
-                    
+                    val startTime = System.currentTimeMillis()
+
+                    indicator.text = "Syncing with Keeper vault..."
+                    KeeperCommandUtils.syncDownBestEffort(logger)
+
                     // Generate password using persistent shell
                     indicator.text = "Generating password..."
-                    val startTime = System.currentTimeMillis()
                     
                     val password = generatePasswordWithRetry() ?: throw RuntimeException("Could not generate password.")
                     
@@ -61,7 +85,7 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
                     indicator.text = "Creating Keeper record..."
                     val recordStartTime = System.currentTimeMillis()
                     
-                    val recordUid = addKeeperRecordWithRetry(title, password, project)
+                    val recordUid = addKeeperRecordWithRetry(target, title, password, project)
                     
                     val recordDuration = System.currentTimeMillis() - recordStartTime
                     logger.info("Record creation completed in ${recordDuration}ms")
@@ -77,21 +101,41 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
                                 document.replaceString(selectionStart, selectionEnd, keeperReference)
                                 FileDocumentManager.getInstance().saveDocument(document)
                             }
+                            val location = when (target) {
+                                is GenerateTarget.Classic ->
+                                    target.folderName?.let { "Classic Vault · $it" } ?: "Classic Vault root"
+                                is GenerateTarget.Drive ->
+                                    target.folderName?.let { "Nested Shared Folder · $it" } ?: "Nested Shared Folder root"
+                            }
                             Messages.showInfoMessage(
                                 project,
-                                "Keeper record created!\n\n$keeperReference\n\nGenerated",
+                                "Keeper record created!\n\n$keeperReference\n\nGenerated in $location",
                                 "Keeper Secret Generated"
                             )
                         }
                     } else {
                         showError("Failed to create Keeper record.", project)
                     }
+                } catch (fatal: KeeperCommandUtils.FatalCommandException) {
+                    logger.error("Keeper Commander reported a fatal error while generating the secret", fatal)
+                    showError(
+                        "Keeper Commander rejected the call:\n\n${fatal.message}\n\n" +
+                            "This usually means the installed Keeper Commander build does not support the " +
+                            "command we issued. Try upgrading Commander (`pip install --upgrade keepercommander`) " +
+                            "or pick a Nested Shared Folder in the target prompt if you are generating a Nested Shared secret.",
+                        project
+                    )
                 } catch (ex: Exception) {
                     logger.error("Error generating Keeper secret", ex)
                     showError("Error: ${ex.message}", project)
                 }
             }
         })
+    }
+
+    private sealed class GenerateTarget {
+        data class Classic(val folderUuid: String?, val folderName: String?) : GenerateTarget()
+        data class Drive(val folderUuid: String?, val folderName: String?) : GenerateTarget()
     }
 
     private val json = Json {
@@ -129,7 +173,8 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
                             }
                             
                             isValid
-                        }
+                        },
+                        fatalErrorDetector = KeeperRecordOutputValidators::isFatalError
                     )
                 ),
                 logger
@@ -187,29 +232,26 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
     }
 
     /**
-     * Add Keeper record using persistent shell with retry logic
+     * Add Keeper record using persistent shell with retry logic.
+     *
+     * Routes to either the classic `record-add` command or the Nested
+     * Share Subfolders `nsf-record-add` command based on [target].
      */
-    private fun addKeeperRecordWithRetry(title: String, password: String, project: Project): String? {
+    private fun addKeeperRecordWithRetry(
+        target: GenerateTarget,
+        title: String,
+        password: String,
+        project: Project
+    ): String? {
         return try {
-            val props = PropertiesComponent.getInstance(project)
-            val folderUUID = props.getValue("keeper.folder.uuid")
-
-            // Build command without 'keeper' prefix (we're in the shell)
-            val cmdParts = mutableListOf(
-                "record-add",
-                "--title=\"$title\"",
-                "--record-type=login"
-            )
-
-            if (!folderUUID.isNullOrBlank()) {
-                cmdParts.add("--folder=\"$folderUUID\"")
-                logger.info("Using folder UUID: $folderUUID")
+            // The password literal is the same for both branches; it must be
+            // single-quoted so the CLI doesn't try to expand $-prefixed chars.
+            val passwordField = "password='$password'"
+            val command = when (target) {
+                is GenerateTarget.Classic -> buildClassicAddCommand(title, passwordField, target.folderUuid)
+                is GenerateTarget.Drive -> buildDriveAddCommand(title, passwordField, target.folderUuid)
             }
-
-            cmdParts.add("password='$password'") // password must be single-quoted for CLI
-
-            val command = cmdParts.joinToString(" ")
-            logger.info("🔧 Running command: $command")
+            logger.info("Issuing ${command.substringBefore(' ')} (target=${if (target is GenerateTarget.Drive) "Drive" else "Classic"})")
             
             val output = KeeperCommandUtils.executeCommandWithRetry(
                 command,
@@ -220,15 +262,19 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
                     logLevel = KeeperCommandUtils.LogLevel.INFO,
                     validation = KeeperCommandUtils.ValidationConfig(
                         minLength = 10, // Should get some meaningful output
-                        customValidator = { output ->
-                            // Should contain a record UID pattern
-                            Regex("""[A-Za-z0-9_-]{22}""").containsMatchIn(output)
-                        }
+                        customValidator = { out ->
+                            val ok = KeeperRecordOutputValidators.isRecordAddSuccess(out)
+                            if (!ok) {
+                                logger.debug("Generate record-add validation failed for output: ${out.take(150)}...")
+                            }
+                            ok
+                        },
+                        fatalErrorDetector = KeeperRecordOutputValidators::isFatalError
                     )
                 ),
                 logger
             )
-            
+
             // Extract record UID from output
             extractRecordUidFromOutput(output)
             
@@ -236,6 +282,50 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
             logger.error("Record creation failed after retries", ex)
             throw ex
         }
+    }
+
+    /**
+     * Build the classic `record-add` command. The folder UUID is resolved
+     * upstream by [KeeperRecordTargetPrompt] (with the project-scope vs
+     * app-scope fallback and the "Pick Folder First" UX); this builder
+     * just consumes the value. `null` / blank means "create at the
+     * Classic Vault root" — no `--folder` flag emitted.
+     */
+    private fun buildClassicAddCommand(title: String, passwordField: String, classicFolderUuid: String?): String {
+        val parts = mutableListOf(
+            "record-add",
+            "--title=\"$title\"",
+            "--record-type=login"
+        )
+        if (!classicFolderUuid.isNullOrBlank()) {
+            parts.add("--folder=\"$classicFolderUuid\"")
+            logger.info("Using classic folder UUID: $classicFolderUuid")
+        } else {
+            logger.info("No classic folder UUID set; record will be created at the vault root")
+        }
+        parts.add(passwordField)
+        return parts.joinToString(" ")
+    }
+
+    /**
+     * Build the `nsf-record-add` command. `nsf-*` commands use space-separated
+     * flag form per the Nested Shared Folders docs; the field literal still
+     * uses the shared `field=value` syntax.
+     */
+    private fun buildDriveAddCommand(title: String, passwordField: String, driveFolderUuid: String?): String {
+        val parts = mutableListOf(
+            "nsf-record-add",
+            "--title", "\"$title\"",
+            "--record-type", "login"
+        )
+        if (!driveFolderUuid.isNullOrBlank()) {
+            parts += listOf("--folder", "\"$driveFolderUuid\"")
+            logger.info("Using Nested Shared Folder UUID: $driveFolderUuid")
+        } else {
+            logger.info("Creating Nested Shared record at the Nested Shared Folder root (no folder UUID set)")
+        }
+        parts.add(passwordField)
+        return parts.joinToString(" ")
     }
 
     /**

--- a/src/main/kotlin/keepersecurity/action/KeeperGenerateSecretsAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGenerateSecretsAction.kt
@@ -16,8 +16,7 @@ import keepersecurity.util.KeeperCliSafety
 import keepersecurity.util.KeeperCommandUtils
 import keepersecurity.util.KeeperJsonUtils
 import keepersecurity.util.KeeperRecordOutputValidators
-import kotlinx.serialization.json.Json  
-import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import keepersecurity.model.GeneratedPassword
 import kotlinx.serialization.ExperimentalSerializationApi
 

--- a/src/main/kotlin/keepersecurity/action/KeeperGenerateSecretsAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGenerateSecretsAction.kt
@@ -245,7 +245,7 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
         return try {
             // The password literal is the same for both branches; it must be
             // single-quoted so the CLI doesn't try to expand $-prefixed chars.
-            val passwordField = "password='$password'"
+            val passwordField = "password='${KeeperCliSafety.escapeSingleQuoted(password)}'"
             val command = when (target) {
                 is GenerateTarget.Classic -> buildClassicAddCommand(title, passwordField, target.folderUuid)
                 is GenerateTarget.Drive -> buildDriveAddCommand(title, passwordField, target.folderUuid)
@@ -291,9 +291,10 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
      * Classic Vault root" — no `--folder` flag emitted.
      */
     private fun buildClassicAddCommand(title: String, passwordField: String, classicFolderUuid: String?): String {
+        val escTitle = KeeperCliSafety.escapeDoubleQuoted(title)
         val parts = mutableListOf(
             "record-add",
-            "--title=\"$title\"",
+            "--title=\"$escTitle\"",
             "--record-type=login"
         )
         if (!classicFolderUuid.isNullOrBlank()) {
@@ -312,9 +313,10 @@ class KeeperGenerateSecretsAction : AnAction("Keeper Generate Secrets") {
      * uses the shared `field=value` syntax.
      */
     private fun buildDriveAddCommand(title: String, passwordField: String, driveFolderUuid: String?): String {
+        val escTitle = KeeperCliSafety.escapeDoubleQuoted(title)
         val parts = mutableListOf(
             "nsf-record-add",
-            "--title", "\"$title\"",
+            "--title", "\"$escTitle\"",
             "--record-type", "login"
         )
         if (!driveFolderUuid.isNullOrBlank()) {

--- a/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
@@ -22,28 +22,52 @@ import keepersecurity.model.getDisplayValue
 import keepersecurity.util.KeeperJsonUtils
 import kotlinx.serialization.ExperimentalSerializationApi
 import keepersecurity.util.KeeperCommandUtils
+import keepersecurity.ui.KeeperListPickerDialog
+import keepersecurity.ui.KeeperListPickerItem
+import keepersecurity.ui.KeeperVaultBadge
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 
+/**
+ * Unified secret picker. Commander's `list --format json` returns both
+ * Classic and Nested Shared records in a single payload (each row carries
+ * a `record_category` discriminator), so a single menu item covers both vault
+ * models — no Nested Shared Folder-specific subclass is needed. Each row
+ * shows the record title with a Classic or Nested badge.
+ *
+ * The `keeper://<uid>/field/<field>` notation accepts both Classic and
+ * Nested Shared record UIDs, so the editor-insertion path doesn't fork on
+ * source.
+ */
 @OptIn(ExperimentalSerializationApi::class)
 class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
+
+    private val taskTitle = "Fetching Keeper Secrets..."
+    private val recordPickerTitle = "Keeper Records"
+    private val emptyRecordsMessage = "No Keeper records found."
+
     private val logger = thisLogger()
 
     override fun actionPerformed(e: AnActionEvent) {
         val project: Project = e.project ?: return
         val editor: Editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
 
-        object : Task.Backgroundable(project, "Fetching Keeper Secrets...", false) {
+        object : Task.Backgroundable(project, taskTitle, false) {
             override fun run(indicator: ProgressIndicator) {
                 
 
                 // Step 1: Get list of records using persistent shell with retry logic
                 val startTime = System.currentTimeMillis()
+
+                indicator.text = "Syncing with Keeper vault..."
+                KeeperCommandUtils.syncDownBestEffort(logger)
+
+                indicator.text = "Fetching Keeper records..."
                 val listJson = try {
                     // Add retry logic for the first run
                     KeeperCommandUtils.executeCommandWithRetry(
-                        "list --format json", 
+                        "list --format json",
                         KeeperCommandUtils.Presets.jsonArray(maxRetries = 3),
                         logger
                     )
@@ -66,34 +90,38 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
                     return
                 }
 
-                val titles = mutableListOf<String>()
-                val uidByTitle = mutableMapOf<String, String>()
-                records.forEach { rec ->
-                    val title = rec.title.ifBlank { "Untitled" }
+                // Build picker rows with Classic / Nested badges.
+                val recordChoices = records.mapNotNull { rec ->
                     val uid = rec.recordUid
-                    if (uid.isNotBlank()) {
-                        titles.add(title)
-                        uidByTitle[title] = uid
-                    }
+                    if (uid.isBlank()) return@mapNotNull null
+                    RecordChoice(
+                        title = rec.title.ifBlank { "Untitled" },
+                        uid = uid,
+                        isNested = rec.isKeeperDrive,
+                    )
                 }
 
-                if (titles.isEmpty()) {
-                    showInfo(project, "No Keeper records found.")
+                if (recordChoices.isEmpty()) {
+                    showInfo(project, emptyRecordsMessage)
                     return
                 }
 
                 // Step 2: Ask user to select record (UI thread)
                 ApplicationManager.getApplication().invokeLater {
-                    val selectedTitle = Messages.showEditableChooseDialog(
-                        "Select Keeper Record:",
-                        "Keeper Records",
-                        null,
-                        titles.toTypedArray(),
-                        titles.first(),
-                        null
+                    val pickerItems = recordChoices.map { it.toPickerItem() }
+                    val selected = KeeperListPickerDialog.pickItem(
+                        project = project,
+                        title = recordPickerTitle,
+                        message = "Select a Keeper record (Classic or Nested Shared Folder):",
+                        options = pickerItems,
+                        initialSelection = pickerItems.first()
                     ) ?: return@invokeLater
 
-                    val selectedUid = uidByTitle[selectedTitle] ?: return@invokeLater
+                    val selectedRecord = recordChoices.find {
+                        it.title == selected.label && it.isNested == (selected.badge == KeeperVaultBadge.NESTED)
+                    } ?: recordChoices.find { it.toPickerItem() == selected }
+                    val selectedUid = selectedRecord?.uid ?: return@invokeLater
+                    val selectedTitle = selectedRecord.title
 
                     // Step 3: Fetch selected record details (background again)
                     object : Task.Backgroundable(project, "Fetching Record Details...", false) {
@@ -243,13 +271,13 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
 
                             // Step 4: Ask user to pick field (UI thread)
                             ApplicationManager.getApplication().invokeLater {
-                                val selectedFieldDisplay = Messages.showEditableChooseDialog(
-                                    "Select field from record '$selectedTitle':",
-                                    "Keeper Record Fields",
-                                    null,
-                                    fieldOptions.map { it.first }.toTypedArray(),
-                                    fieldOptions.first().first,
-                                    null
+                                val fieldLabels = fieldOptions.map { it.first }
+                                val selectedFieldDisplay = KeeperListPickerDialog.pick(
+                                    project = project,
+                                    title = "Keeper Record Fields",
+                                    message = "Select field from record '$selectedTitle':",
+                                    options = fieldLabels,
+                                    initialSelection = fieldLabels.first()
                                 ) ?: return@invokeLater
 
                                 val selectedFieldKey = fieldOptions.find { it.first == selectedFieldDisplay }?.second ?: return@invokeLater
@@ -352,5 +380,16 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
         ApplicationManager.getApplication().invokeLater {
             Messages.showInfoMessage(project, message, "Info")
         }
+    }
+
+    private data class RecordChoice(
+        val title: String,
+        val uid: String,
+        val isNested: Boolean,
+    ) {
+        fun toPickerItem() = KeeperListPickerItem(
+            label = title,
+            badge = if (isNested) KeeperVaultBadge.NESTED else KeeperVaultBadge.CLASSIC,
+        )
     }
 }

--- a/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
@@ -116,9 +116,9 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
                         initialSelection = pickerItems.first()
                     ) ?: return@invokeLater
 
-                    val selectedRecord = recordChoices.find {
-                        it.title == selected.label && it.isNested == (selected.badge == KeeperVaultBadge.NESTED)
-                    } ?: recordChoices.find { it.toPickerItem() == selected }
+                    val selectedRecord = selected.id?.let { uid ->
+                        recordChoices.find { it.uid == uid }
+                    }
                     val selectedUid = selectedRecord?.uid ?: return@invokeLater
                     val selectedTitle = selectedRecord.title
 
@@ -389,6 +389,7 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
         fun toPickerItem() = KeeperListPickerItem(
             label = title,
             badge = if (isNested) KeeperVaultBadge.NESTED else KeeperVaultBadge.CLASSIC,
+            id = uid,
         )
     }
 }

--- a/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
@@ -16,7 +16,6 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.vfs.VirtualFile
 import keepersecurity.service.KeeperShellService
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.decodeFromString
 import keepersecurity.model.KeeperRecord
 import keepersecurity.model.getDisplayValue
 import keepersecurity.util.KeeperJsonUtils
@@ -365,7 +364,7 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
         insertText: String,
         keeperNotation: String,
     ): String = if (isHttpSnippet) {
-        "HTTP Client variable inserted (record and field chosen from the list — no UID to type).\n\n$insertText"
+        "HTTP Client variable inserted (record and field chosen from the list — no uid to type).\n\n$insertText"
     } else {
         "Keeper reference inserted!\n\n$keeperNotation"
     }

--- a/src/main/kotlin/keepersecurity/action/KeeperRecordAddAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperRecordAddAction.kt
@@ -201,9 +201,10 @@ class KeeperRecordAddAction : AnAction("Add Keeper Record") {
      * `--folder` flag emitted.
      */
     private fun buildClassicAddCommand(title: String, formattedField: String, classicFolderUuid: String?): String {
+        val escTitle = KeeperCliSafety.escapeDoubleQuoted(title)
         val parts = mutableListOf(
             "record-add",
-            "--title=\"$title\"",
+            "--title=\"$escTitle\"",
             "--record-type=login"
         )
         if (!classicFolderUuid.isNullOrBlank()) {
@@ -218,9 +219,10 @@ class KeeperRecordAddAction : AnAction("Add Keeper Record") {
 
     private fun buildDriveAddCommand(title: String, formattedField: String, driveFolderUuid: String?): String {
         // `nsf-record-add` uses space-separated flag form per the Nested Shared Folders docs.
+        val escTitle = KeeperCliSafety.escapeDoubleQuoted(title)
         val parts = mutableListOf(
             "nsf-record-add",
-            "--title", "\"$title\"",
+            "--title", "\"$escTitle\"",
             "--record-type", "login"
         )
         if (!driveFolderUuid.isNullOrBlank()) {
@@ -236,14 +238,17 @@ class KeeperRecordAddAction : AnAction("Add Keeper Record") {
     private fun formatField(fieldName: String, selectedText: String): String = when {
         fieldName == "password" && selectedText.startsWith("\$GEN", ignoreCase = true) -> {
             // Special case: random password generation
-            "$fieldName='$selectedText'"
+            "$fieldName='${KeeperCliSafety.escapeSingleQuoted(selectedText)}'"
         }
         fieldName in keeperStandardFields -> {
-            "$fieldName=\"$selectedText\""
+            val esc = KeeperCliSafety.escapeDoubleQuoted(selectedText)
+            "$fieldName=\"$esc\""
         }
         else -> {
             // Custom field
-            "\"$fieldName\"=\"$selectedText\""
+            val escName = KeeperCliSafety.escapeDoubleQuoted(fieldName)
+            val escValue = KeeperCliSafety.escapeDoubleQuoted(selectedText)
+            "\"$escName\"=\"$escValue\""
         }
     }
 

--- a/src/main/kotlin/keepersecurity/action/KeeperRecordAddAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperRecordAddAction.kt
@@ -11,9 +11,10 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.diagnostic.thisLogger
-import com.intellij.ide.util.PropertiesComponent
 import keepersecurity.service.KeeperShellService
+import keepersecurity.util.KeeperCliSafety
 import keepersecurity.util.KeeperCommandUtils
+import keepersecurity.util.KeeperRecordOutputValidators
 
 class KeeperRecordAddAction : AnAction("Add Keeper Record") {
     private val logger = thisLogger()
@@ -31,34 +32,68 @@ class KeeperRecordAddAction : AnAction("Add Keeper Record") {
         val editor: Editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
         val document = editor.document
         val caret = editor.caretModel.currentCaret
-        val selectedText = caret.selectedText?.trim()
+        val rawSelection = caret.selectedText?.trim()
 
-        if (selectedText.isNullOrBlank()) {
+        if (rawSelection.isNullOrBlank()) {
             showError("Please select the text you want to store in Keeper.", project)
             return
         }
 
-        // Get input from user on EDT
-        val title = Messages.showInputDialog(project, "Enter Keeper record title:", "Record Title", null)
-            ?.takeIf { it.isNotBlank() } ?: return
+        val selectedText = try {
+            KeeperCliSafety.requireSafe(rawSelection, "selected text")
+        } catch (ex: KeeperCliSafety.UnsafeCliInputException) {
+            showError(ex.message ?: "Selected text is not safe to send to Keeper.", project)
+            return
+        }
 
-        val fieldName = Messages.showInputDialog(
-            project, 
-            "Enter Keeper field type (e.g., login, password, url, or custom field name):", 
-            "Field Type", 
+        // Ask whether this record should land in the Classic vault or in a Nested Shared Folder
+        // BEFORE prompting for any record metadata. This avoids wasting the user's
+        // inputs if they cancel out of the target dialog.
+        val target = when (val outcome = KeeperRecordTargetPrompt.promptForAddTarget(project)) {
+            is KeeperRecordTargetPrompt.AddOutcome.Cancelled -> return
+            is KeeperRecordTargetPrompt.AddOutcome.Classic -> AddTarget.Classic(outcome.folderUuid, outcome.folderName)
+            is KeeperRecordTargetPrompt.AddOutcome.Drive -> AddTarget.Drive(outcome.folderUuid, outcome.folderName)
+        }
+
+        // Get input from user on EDT
+        val rawTitle = Messages.showInputDialog(project, "Enter Keeper record title:", "Record Title", null)
+            ?.takeIf { it.isNotBlank() } ?: return
+        val title = try {
+            KeeperCliSafety.requireSafe(rawTitle, "record title")
+        } catch (ex: KeeperCliSafety.UnsafeCliInputException) {
+            showError(ex.message ?: "Record title is not safe.", project)
+            return
+        }
+
+        val rawFieldName = Messages.showInputDialog(
+            project,
+            "Enter Keeper field type (e.g., login, password, url, or custom field name):",
+            "Field Type",
             null
         )?.takeIf { it.isNotBlank() } ?: return
+        val fieldName = try {
+            KeeperCliSafety.requireSafe(rawFieldName, "field name")
+        } catch (ex: KeeperCliSafety.UnsafeCliInputException) {
+            showError(ex.message ?: "Field name is not safe.", project)
+            return
+        }
 
         // Run the record creation in background
-        object : Task.Backgroundable(project, "Creating Keeper Record...", false) {
+        val taskTitle = when (target) {
+            is AddTarget.Classic -> "Creating Keeper Record..."
+            is AddTarget.Drive -> "Creating Nested Shared Record..."
+        }
+        object : Task.Backgroundable(project, taskTitle, false) {
             override fun run(indicator: ProgressIndicator) {
-                
-                
                 try {
                     val startTime = System.currentTimeMillis()
-                    
+
+                    indicator.text = "Syncing with Keeper vault..."
+                    KeeperCommandUtils.syncDownBestEffort(logger)
+
+                    indicator.text = taskTitle
                     // Create the record using persistent shell
-                    val recordUid = createKeeperRecord(title, fieldName, selectedText)
+                    val recordUid = createKeeperRecord(project, target, title, fieldName, selectedText)
                     
                     val duration = System.currentTimeMillis() - startTime
                     logger.info("Record created in ${duration}ms")
@@ -74,13 +109,28 @@ class KeeperRecordAddAction : AnAction("Add Keeper Record") {
                             FileDocumentManager.getInstance().saveDocument(document)
                         }
 
+                        val location = when (target) {
+                            is AddTarget.Classic -> target.folderName?.let { "Classic Vault · $it" } ?: "Classic Vault root"
+                            is AddTarget.Drive -> target.folderName?.let { "Nested Shared Folder · $it" } ?: "Nested Shared Folder root"
+                        }
                         Messages.showInfoMessage(
-                            project, 
-                            "Keeper record created!\n\n$keeperReference\n\nCreated", 
+                            project,
+                            "Keeper record created!\n\n$keeperReference\n\nCreated in $location",
                             "Keeper Record Added"
                         )
                     }
                     
+                } catch (fatal: KeeperCommandUtils.FatalCommandException) {
+                    logger.error("Keeper Commander reported a fatal error while creating the record", fatal)
+                    ApplicationManager.getApplication().invokeLater {
+                        showError(
+                            "Keeper Commander rejected the record-add call:\n\n${fatal.message}\n\n" +
+                                "This usually means the installed Keeper Commander build does not support the " +
+                                "command we issued. Try upgrading Commander (`pip install --upgrade keepercommander`) " +
+                                "or pick a Nested Shared Folder in the target prompt if you are creating a Nested Shared record.",
+                            project
+                        )
+                    }
                 } catch (ex: Exception) {
                     logger.error("Failed to create Keeper record", ex)
                     ApplicationManager.getApplication().invokeLater {
@@ -92,44 +142,26 @@ class KeeperRecordAddAction : AnAction("Add Keeper Record") {
     }
 
     /**
-     * Create a Keeper record using the persistent shell service
+     * Create a Keeper record using the persistent shell service. Routes to
+     * either the classic `record-add` command or the Nested Shared Folder
+     * Subfolders `nsf-record-add` command based on [target].
      */
-    private fun createKeeperRecord(title: String, fieldName: String, selectedText: String): String {
-        // Load folder UUID from local storage
-        val props = PropertiesComponent.getInstance()
-        val folderUUID = props.getValue("keeper.folder.uuid")
-
-        // Build keeper command (without "keeper" prefix since we're in the shell)
-        val commandParts = mutableListOf(
-            "record-add",
-            "--title=\"$title\"",
-            "--record-type=login"
-        )
-
-        if (!folderUUID.isNullOrBlank()) {
-            commandParts.add("--folder=\"$folderUUID\"")
-            logger.info("Using folder UUID: $folderUUID")
+    private fun createKeeperRecord(
+        project: Project,
+        target: AddTarget,
+        title: String,
+        fieldName: String,
+        selectedText: String
+    ): String {
+        val formattedField = formatField(fieldName, selectedText)
+        val command = when (target) {
+            is AddTarget.Classic -> buildClassicAddCommand(title, formattedField, target.folderUuid)
+            is AddTarget.Drive -> buildDriveAddCommand(title, formattedField, target.folderUuid)
         }
 
-        // Format the field based on type and content
-        val formattedField: String = when {
-            fieldName == "password" && selectedText.startsWith("\$GEN", ignoreCase = true) -> {
-                // Special case: random password generation
-                "$fieldName='$selectedText'"
-            }
-            fieldName in keeperStandardFields -> {
-                "$fieldName=\"$selectedText\""
-            }
-            else -> {
-                // Custom field
-                "\"$fieldName\"=\"$selectedText\""
-            }
-        }
-
-        commandParts.add(formattedField)
-
-        val command = commandParts.joinToString(" ")
-        logger.info("Creating record with command: $command")
+        val verb = command.substringBefore(' ')
+        logger.info("Issuing $verb (target=${if (target is AddTarget.Drive) "Drive" else "Classic"}, " +
+            "hasFolder=${command.contains("--folder")})")
 
         // Execute with proper validation for record creation
         val output = KeeperCommandUtils.executeCommandWithRetry(
@@ -140,34 +172,84 @@ class KeeperRecordAddAction : AnAction("Add Keeper Record") {
                 retryDelayMs = 2000, // Longer delay between retries
                 logLevel = KeeperCommandUtils.LogLevel.INFO,
                 validation = KeeperCommandUtils.ValidationConfig(
-                    customValidator = { output ->
-                        // Should contain a record UID and NOT be sync status
-                        val hasUid = Regex("""[A-Za-z0-9_-]{22}""").containsMatchIn(output)
-                        val isNotSyncStatus = !output.contains("Decrypted [") && 
-                                            !output.contains("record(s)") &&
-                                            !output.contains("breachwatch list") &&
-                                            !output.contains("Use \"breachwatch list\" command")
-                        
-                        val isValid = hasUid && isNotSyncStatus
-                        
-                        if (!isValid) {
-                            logger.debug("Record creation validation failed - hasUid: $hasUid, isNotSyncStatus: $isNotSyncStatus")
-                            logger.debug("Output: ${output.take(150)}...")
+                    customValidator = { out ->
+                        val ok = KeeperRecordOutputValidators.isRecordAddSuccess(out)
+                        if (!ok) {
+                            logger.debug("Record creation validation failed for output: ${out.take(150)}...")
                         }
-                        
-                        isValid
-                    }
+                        ok
+                    },
+                    fatalErrorDetector = KeeperRecordOutputValidators::isFatalError
                 )
             ),
             logger
         )
 
         // Extract UID from output
-        val recordUid = Regex("""[A-Za-z0-9_-]{22}""").find(output)?.value
+        val recordUid = KeeperRecordOutputValidators.extractRecordUid(output)
             ?: throw RuntimeException("Could not find UID in Keeper CLI output. Output: $output")
 
         logger.info("Created record with UID: $recordUid")
         return recordUid
+    }
+
+    /**
+     * The classic folder UUID is now resolved (with the project-scope vs
+     * app-scope fallback and the "Pick Folder First" UX) by
+     * [KeeperRecordTargetPrompt]; this builder just consumes the value.
+     * `null` / blank means "create at the Classic Vault root" — no
+     * `--folder` flag emitted.
+     */
+    private fun buildClassicAddCommand(title: String, formattedField: String, classicFolderUuid: String?): String {
+        val parts = mutableListOf(
+            "record-add",
+            "--title=\"$title\"",
+            "--record-type=login"
+        )
+        if (!classicFolderUuid.isNullOrBlank()) {
+            parts.add("--folder=\"$classicFolderUuid\"")
+            logger.info("Using classic folder UUID: $classicFolderUuid")
+        } else {
+            logger.info("No classic folder UUID set; record will be created at the vault root")
+        }
+        parts.add(formattedField)
+        return parts.joinToString(" ")
+    }
+
+    private fun buildDriveAddCommand(title: String, formattedField: String, driveFolderUuid: String?): String {
+        // `nsf-record-add` uses space-separated flag form per the Nested Shared Folders docs.
+        val parts = mutableListOf(
+            "nsf-record-add",
+            "--title", "\"$title\"",
+            "--record-type", "login"
+        )
+        if (!driveFolderUuid.isNullOrBlank()) {
+            parts += listOf("--folder", "\"$driveFolderUuid\"")
+            logger.info("Using Nested Shared Folder UUID: $driveFolderUuid")
+        } else {
+            logger.info("Creating Nested Shared record at the Nested Shared Folder root (no folder UUID set)")
+        }
+        parts.add(formattedField)
+        return parts.joinToString(" ")
+    }
+
+    private fun formatField(fieldName: String, selectedText: String): String = when {
+        fieldName == "password" && selectedText.startsWith("\$GEN", ignoreCase = true) -> {
+            // Special case: random password generation
+            "$fieldName='$selectedText'"
+        }
+        fieldName in keeperStandardFields -> {
+            "$fieldName=\"$selectedText\""
+        }
+        else -> {
+            // Custom field
+            "\"$fieldName\"=\"$selectedText\""
+        }
+    }
+
+    private sealed class AddTarget {
+        data class Classic(val folderUuid: String?, val folderName: String?) : AddTarget()
+        data class Drive(val folderUuid: String?, val folderName: String?) : AddTarget()
     }
 
     private fun showError(message: String, project: Project) {

--- a/src/main/kotlin/keepersecurity/action/KeeperRecordTargetPrompt.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperRecordTargetPrompt.kt
@@ -1,0 +1,284 @@
+package keepersecurity.action
+
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import keepersecurity.util.KeeperFolderValidator
+
+/**
+ * Shared helper that resolves the vault target (Classic vs Nested Shared
+ * Subfolder) for *Add Keeper Record* and *Generate Keeper Secret*.
+ *
+ * Keeper maintains two parallel folder/permission models — Classic and Nested
+ * Shared Subfolders (v3 API, `nsf-*` commands). Both models have folders
+ * and records; Commander tags folder rows with `source` and record rows with
+ * `record_category`. Since *Get Keeper Folder* is now unified — picking a
+ * folder writes exactly one of the Classic / Nested Shared Folder slots
+ * and clears the other — the saved folder already encodes the user's intent. We validate the saved
+ * UUID against the current `ls --format=json -f -R` payload via
+ * [KeeperFolderValidator] and dispatch directly. If the saved folder
+ * has been deleted, moved between vaults, or simply doesn't exist for
+ * this account, we clear it and surface a single "run *Get Keeper
+ * Folder* first" info dialog (no "use root" escape hatch — root
+ * creation can be expressed by deliberately picking a top-level folder).
+ *
+ * The corresponding *Update Keeper Record* prompt was retired in favour
+ * of [keepersecurity.util.KeeperRecordValidator], which looks up the
+ * user-supplied record UID in `list --format json` and dispatches to
+ * `record-update` vs `nsf-record-update` based on the row's
+ * `record_category`.
+ */
+object KeeperRecordTargetPrompt {
+
+    private val logger = thisLogger()
+
+    /**
+     * Preference keys (per-project).
+     */
+    const val PREF_DRIVE_FOLDER_UUID = "keeper.drive.folder.uuid"
+    const val PREF_DRIVE_FOLDER_NAME = "keeper.drive.folder.name"
+    const val PREF_CLASSIC_FOLDER_UUID = "keeper.folder.uuid"
+    const val PREF_CLASSIC_FOLDER_NAME = "keeper.folder.name"
+
+    /**
+     * Outcome of [promptForAddTarget] / [promptForGenerateTarget].
+     *
+     * Both [Classic] and [Drive] carry the resolved folder UUID + display
+     * name so the caller doesn't have to re-read `PropertiesComponent`
+     * (and pick the wrong scope — see the project-scope vs app-scope
+     * footgun fixed earlier).
+     *
+     * `folderUuid == null` is no longer reachable for Add / Generate
+     * because we won't dispatch to those branches without a verified
+     * folder — the nullability is preserved on the data class for API
+     * compatibility with callers that build outcomes from tests.
+     */
+    sealed class AddOutcome {
+        object Cancelled : AddOutcome()
+        data class Classic(val folderUuid: String?, val folderName: String?) : AddOutcome()
+        data class Drive(val folderUuid: String?, val folderName: String?) : AddOutcome()
+    }
+
+    /**
+     * Resolve the target for an *Add Keeper Record* action.
+     *
+     * Auto-dispatches based on the saved folder slot. Returns
+     * [AddOutcome.Cancelled] when no folder is saved (after showing a
+     * single "run *Get Keeper Folder* first" info dialog) or when the
+     * saved folder is stale (slot is cleared, same dialog is shown with
+     * a prefix explaining what was cleared).
+     *
+     * Must be called on the EDT — both the validator's progress modal
+     * and the info dialog require it.
+     */
+    fun promptForAddTarget(project: Project, dialogTitle: String = "Add Keeper Record"): AddOutcome =
+        dispatchByFolder(project, dialogTitle)
+
+    /**
+     * Same dispatch logic as [promptForAddTarget]; separate signature for
+     * call-site clarity in `KeeperGenerateSecretsAction`.
+     */
+    fun promptForGenerateTarget(project: Project, dialogTitle: String = "Generate Keeper Secret"): AddOutcome =
+        dispatchByFolder(project, dialogTitle)
+
+    /**
+     * Resolve the Add / Generate dispatch based on the saved folder slot.
+     * Drive slot wins if (somehow) both are set — in practice
+     * `KeeperFolderSelectAction.persistFolderSelection` clears the other
+     * side, so only one is populated at any time.
+     */
+    private fun dispatchByFolder(project: Project, dialogTitle: String): AddOutcome {
+        val driveAttempt = tryDriveSlot(project)
+        if (driveAttempt is SlotResult.Resolved) return driveAttempt.outcome
+
+        val classicAttempt = tryClassicSlot(project)
+        if (classicAttempt is SlotResult.Resolved) return classicAttempt.outcome
+
+        // Either no slot was populated, or the populated slot was stale
+        // and got cleared. Surface the stale reason if we have one — it
+        // explains *why* the user is being told to re-pick.
+        val stalePrefix = (driveAttempt as? SlotResult.Cleared)?.reason
+            ?: (classicAttempt as? SlotResult.Cleared)?.reason
+
+        showFolderPickerHint(
+            project = project,
+            dialogTitle = dialogTitle,
+            stalePrefix = stalePrefix
+        )
+        return AddOutcome.Cancelled
+    }
+
+    /** What happened when we examined a slot. */
+    private sealed class SlotResult {
+        /** Slot was empty — nothing to do. */
+        object Empty : SlotResult()
+
+        /** Slot resolved to a valid folder; downstream should use it. */
+        data class Resolved(val outcome: AddOutcome) : SlotResult()
+
+        /**
+         * Slot was populated but stale and has been cleared. [reason] is
+         * a user-facing sentence that the caller can prepend to the
+         * next dialog.
+         */
+        data class Cleared(val reason: String) : SlotResult()
+    }
+
+    private fun tryDriveSlot(project: Project): SlotResult {
+        val props = PropertiesComponent.getInstance(project)
+        val savedUuid = props.getValue(PREF_DRIVE_FOLDER_UUID)?.takeIf { it.isNotBlank() }
+            ?: return SlotResult.Empty
+        val savedName = props.getValue(PREF_DRIVE_FOLDER_NAME)?.takeIf { it.isNotBlank() }
+
+        return when (val verdict = KeeperFolderValidator.verifySavedFolder(
+            project = project,
+            uuid = savedUuid,
+            expected = KeeperFolderValidator.ExpectedKind.DRIVE
+        )) {
+            is KeeperFolderValidator.Verdict.Valid -> {
+                logger.info("Auto-dispatching to Nested Shared Folder: '${verdict.name}' ($savedUuid)")
+                SlotResult.Resolved(AddOutcome.Drive(folderUuid = savedUuid, folderName = verdict.name))
+            }
+            is KeeperFolderValidator.Verdict.Missing -> {
+                logger.warn("Saved Nested Shared Folder '${savedName ?: savedUuid}' ($savedUuid) " +
+                    "is no longer in the vault listing; clearing the saved slot")
+                clearDriveFolder(project)
+                SlotResult.Cleared(
+                    "The previously selected Nested Shared Folder " +
+                        "'${savedName ?: savedUuid}' is no longer available and has been cleared. "
+                )
+            }
+            is KeeperFolderValidator.Verdict.Mismatch -> {
+                logger.warn("Saved Nested Shared Folder UUID '$savedUuid' actually points to a Classic folder " +
+                    "('${verdict.name}'); clearing the Nested Shared Folder slot")
+                clearDriveFolder(project)
+                SlotResult.Cleared(
+                    "The folder previously saved as Nested Shared Folder ('${verdict.name}') " +
+                        "is actually a Classic Vault folder. The Nested Shared Folder selection has been cleared. "
+                )
+            }
+            is KeeperFolderValidator.Verdict.Unknown -> {
+                // Fail-soft: a transient CLI hiccup shouldn't wipe a
+                // possibly valid UUID. Let downstream `record-add` raise
+                // the real error if the folder is genuinely gone.
+                logger.warn("Could not verify saved Nested Shared Folder ($savedUuid): " +
+                    "${verdict.reason}; proceeding with the saved value")
+                SlotResult.Resolved(AddOutcome.Drive(folderUuid = savedUuid, folderName = savedName))
+            }
+        }
+    }
+
+    private fun tryClassicSlot(project: Project): SlotResult {
+        val (savedUuid, savedName) = readSavedClassicFolder(project)
+        if (savedUuid == null) return SlotResult.Empty
+
+        return when (val verdict = KeeperFolderValidator.verifySavedFolder(
+            project = project,
+            uuid = savedUuid,
+            expected = KeeperFolderValidator.ExpectedKind.CLASSIC
+        )) {
+            is KeeperFolderValidator.Verdict.Valid -> {
+                logger.info("Auto-dispatching to classic folder: '${verdict.name}' ($savedUuid)")
+                SlotResult.Resolved(AddOutcome.Classic(folderUuid = savedUuid, folderName = verdict.name))
+            }
+            is KeeperFolderValidator.Verdict.Missing -> {
+                logger.warn("Saved classic folder '${savedName ?: savedUuid}' ($savedUuid) " +
+                    "is no longer in the vault listing; clearing the saved slot")
+                clearClassicFolder(project)
+                SlotResult.Cleared(
+                    "The previously selected Classic Vault folder " +
+                        "'${savedName ?: savedUuid}' is no longer available and has been cleared. "
+                )
+            }
+            is KeeperFolderValidator.Verdict.Mismatch -> {
+                logger.warn("Saved classic UUID '$savedUuid' actually points to a Nested Shared Folder " +
+                    "('${verdict.name}'); clearing the classic slot")
+                clearClassicFolder(project)
+                SlotResult.Cleared(
+                    "The folder previously saved as Classic ('${verdict.name}') " +
+                        "now lives in a Nested Shared Folder. The Classic selection has been cleared. "
+                )
+            }
+            is KeeperFolderValidator.Verdict.Unknown -> {
+                logger.warn("Could not verify saved classic folder ($savedUuid): " +
+                    "${verdict.reason}; proceeding with the saved value")
+                SlotResult.Resolved(AddOutcome.Classic(folderUuid = savedUuid, folderName = savedName))
+            }
+        }
+    }
+
+    /**
+     * Wipe the classic folder slot from both the project-scope and the
+     * legacy application-scope `PropertiesComponent`. The app-scope clear
+     * mirrors the dual-read in [readSavedClassicFolder] so a stale legacy
+     * value can't re-surface on the next prompt.
+     */
+    private fun clearClassicFolder(project: Project) {
+        val projectProps = PropertiesComponent.getInstance(project)
+        projectProps.unsetValue(PREF_CLASSIC_FOLDER_UUID)
+        projectProps.unsetValue(PREF_CLASSIC_FOLDER_NAME)
+
+        val appProps = PropertiesComponent.getInstance()
+        appProps.unsetValue(PREF_CLASSIC_FOLDER_UUID)
+        appProps.unsetValue(PREF_CLASSIC_FOLDER_NAME)
+    }
+
+    /** Wipe the Nested Shared Folder slot (project-scope only — this slot was never app-scope). */
+    private fun clearDriveFolder(project: Project) {
+        val props = PropertiesComponent.getInstance(project)
+        props.unsetValue(PREF_DRIVE_FOLDER_UUID)
+        props.unsetValue(PREF_DRIVE_FOLDER_NAME)
+    }
+
+    /**
+     * Read the persisted classic folder, project-scope first with an
+     * application-scope fallback for installs that saved the UUID under
+     * the older app-wide key. Returns `(uuid, name)` or `(null, null)`.
+     */
+    private fun readSavedClassicFolder(project: Project): Pair<String?, String?> {
+        val projectProps = PropertiesComponent.getInstance(project)
+        val appProps = PropertiesComponent.getInstance()
+
+        val uuid = projectProps.getValue(PREF_CLASSIC_FOLDER_UUID)?.takeIf { it.isNotBlank() }
+            ?: appProps.getValue(PREF_CLASSIC_FOLDER_UUID)?.takeIf { it.isNotBlank() }
+            ?: return null to null
+
+        val name = projectProps.getValue(PREF_CLASSIC_FOLDER_NAME)?.takeIf { it.isNotBlank() }
+            ?: appProps.getValue(PREF_CLASSIC_FOLDER_NAME)?.takeIf { it.isNotBlank() }
+
+        return uuid to name
+    }
+
+    /**
+     * The single info dialog shown when Add / Generate can't dispatch
+     * because the project has no saved folder (either never picked, or
+     * the previous pick has been cleared by the validator). The
+     * [stalePrefix] parameter, when non-null, explains *why* the saved
+     * value was cleared so the user isn't left guessing.
+     */
+    private fun showFolderPickerHint(
+        project: Project,
+        dialogTitle: String,
+        stalePrefix: String? = null
+    ) {
+        val message = (stalePrefix ?: "No Keeper folder is selected for this project. ") +
+            "Run \"Get Keeper Folder\" from the Tools \u2192 Keeper Vault menu to pick a folder, " +
+            "then try this action again."
+
+        invokeAndWait {
+            Messages.showInfoMessage(project, message, dialogTitle)
+        }
+    }
+
+    private fun invokeAndWait(block: () -> Unit) {
+        val app = ApplicationManager.getApplication()
+        if (app.isDispatchThread) {
+            block()
+        } else {
+            app.invokeAndWait(block, ModalityState.any())
+        }
+    }
+}

--- a/src/main/kotlin/keepersecurity/action/KeeperRecordTargetPrompt.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperRecordTargetPrompt.kt
@@ -46,7 +46,7 @@ object KeeperRecordTargetPrompt {
     /**
      * Outcome of [promptForAddTarget] / [promptForGenerateTarget].
      *
-     * Both [Classic] and [Drive] carry the resolved folder UUID + display
+     * Both [AddOutcome.Classic] and [AddOutcome.Drive] carry the resolved folder UUID + display
      * name so the caller doesn't have to re-read `PropertiesComponent`
      * (and pick the wrong scope — see the project-scope vs app-scope
      * footgun fixed earlier).
@@ -57,7 +57,7 @@ object KeeperRecordTargetPrompt {
      * compatibility with callers that build outcomes from tests.
      */
     sealed class AddOutcome {
-        object Cancelled : AddOutcome()
+        data object Cancelled : AddOutcome()
         data class Classic(val folderUuid: String?, val folderName: String?) : AddOutcome()
         data class Drive(val folderUuid: String?, val folderName: String?) : AddOutcome()
     }
@@ -114,7 +114,7 @@ object KeeperRecordTargetPrompt {
     /** What happened when we examined a slot. */
     private sealed class SlotResult {
         /** Slot was empty — nothing to do. */
-        object Empty : SlotResult()
+        data object Empty : SlotResult()
 
         /** Slot resolved to a valid folder; downstream should use it. */
         data class Resolved(val outcome: AddOutcome) : SlotResult()

--- a/src/main/kotlin/keepersecurity/action/KeeperRecordUpdateAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperRecordUpdateAction.kt
@@ -154,9 +154,12 @@ class KeeperRecordUpdateAction : AnAction("Update Keeper Record") {
                     indicator.text = taskTitle
                     // Format the field properly for the shell command
                     val formattedField = if (fieldName in keeperStandardFields) {
-                        "$fieldName=\"$safeSelectionText\""
+                        val esc = KeeperCliSafety.escapeDoubleQuoted(safeSelectionText)
+                        "$fieldName=\"$esc\""
                     } else {
-                        "\"$fieldName\"=\"$safeSelectionText\""
+                        val escName = KeeperCliSafety.escapeDoubleQuoted(fieldName)
+                        val escValue = KeeperCliSafety.escapeDoubleQuoted(safeSelectionText)
+                        "\"$escName\"=\"$escValue\""
                     }
 
                     // Build the command without "keeper" prefix since we're in the shell.

--- a/src/main/kotlin/keepersecurity/action/KeeperRecordUpdateAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperRecordUpdateAction.kt
@@ -14,7 +14,10 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.TextRange
 import keepersecurity.service.KeeperShellService
+import keepersecurity.util.KeeperCliSafety
 import keepersecurity.util.KeeperCommandUtils
+import keepersecurity.util.KeeperRecordOutputValidators
+import keepersecurity.util.KeeperRecordValidator
 
 class KeeperRecordUpdateAction : AnAction("Update Keeper Record") {
     private val logger = thisLogger()
@@ -58,19 +61,66 @@ class KeeperRecordUpdateAction : AnAction("Update Keeper Record") {
             return
         }
 
-        val recordUid = Messages.showInputDialog(
+        val safeSelectionText = try {
+            KeeperCliSafety.requireSafe(selectionData.text!!, "selected value")
+        } catch (ex: KeeperCliSafety.UnsafeCliInputException) {
+            showError(ex.message ?: "Selected value is not safe to send to Keeper.", project)
+            return
+        }
+
+        val rawRecordUid = Messages.showInputDialog(
             project,
             "Enter Keeper record UID:",
             "Record UID",
             null
         )?.trim()
 
-        if (recordUid.isNullOrBlank()) {
+        if (rawRecordUid.isNullOrBlank()) {
             showError("Record UID is required", project)
             return
         }
 
-        val fieldName = Messages.showInputDialog(
+        val recordUid = try {
+            KeeperCliSafety.requireSafe(rawRecordUid, "record UID")
+        } catch (ex: KeeperCliSafety.UnsafeCliInputException) {
+            showError(ex.message ?: "Record UID is not safe.", project)
+            return
+        }
+
+        // Look up the UID in the vault to decide which CLI command to use.
+        // `list --format json` includes a `record_category` discriminator
+        // (`Classic` / `Nested`, plus older legacy wire values) that maps 1:1 onto
+        // `record-update` vs `nsf-record-update`, so the user never has to tell us
+        // which namespace their UID lives in.
+        // The lookup also rejects typo'd or deleted UIDs up-front instead
+        // of letting them surface as a confusing "record not found"
+        // mid-update.
+        val isDrive = when (val verdict = KeeperRecordValidator.lookupRecord(project, recordUid)) {
+            is KeeperRecordValidator.Verdict.Found -> {
+                logger.info("Auto-dispatching update for record '${verdict.title}' ($recordUid) " +
+                    "to ${if (verdict.kind == KeeperRecordValidator.Kind.DRIVE) "Nested Shared Folder" else "Classic Vault"}")
+                verdict.kind == KeeperRecordValidator.Kind.DRIVE
+            }
+            is KeeperRecordValidator.Verdict.NotFound -> {
+                showError(
+                    "Record UID '$recordUid' was not found in your vault. " +
+                        "Double-check the value (Tools \u2192 Keeper Vault \u2192 Get Keeper Secret " +
+                        "lists every record with its UID).",
+                    project
+                )
+                return
+            }
+            is KeeperRecordValidator.Verdict.Unknown -> {
+                showError(
+                    "Couldn't verify the record UID against your vault " +
+                        "(${verdict.reason}). Make sure Keeper Commander is healthy and try again.",
+                    project
+                )
+                return
+            }
+        }
+
+        val rawFieldName = Messages.showInputDialog(
             project,
             "Enter Keeper field name (e.g., login, password, url, or custom):",
             "Field Name",
@@ -79,30 +129,46 @@ class KeeperRecordUpdateAction : AnAction("Update Keeper Record") {
             null
         )?.trim()
 
-        if (fieldName.isNullOrBlank()) {
+        if (rawFieldName.isNullOrBlank()) {
             showError("Field name is required", project)
             return
         }
 
+        val fieldName = try {
+            KeeperCliSafety.requireSafe(rawFieldName, "field name")
+        } catch (ex: KeeperCliSafety.UnsafeCliInputException) {
+            showError(ex.message ?: "Field name is not safe.", project)
+            return
+        }
+
+        val taskTitle = if (isDrive) "Updating Nested Shared Record..." else "Updating Keeper Record..."
         // Execute the update in background using persistent shell
-        object : Task.Backgroundable(project, "Updating Keeper Record...", false) {
+        object : Task.Backgroundable(project, taskTitle, false) {
             override fun run(indicator: ProgressIndicator) {
-                
-                
                 try {
                     val startTime = System.currentTimeMillis()
-                    
+
+                    indicator.text = "Syncing with Keeper vault..."
+                    KeeperCommandUtils.syncDownBestEffort(logger)
+
+                    indicator.text = taskTitle
                     // Format the field properly for the shell command
                     val formattedField = if (fieldName in keeperStandardFields) {
-                        "$fieldName=\"${selectionData.text}\""
+                        "$fieldName=\"$safeSelectionText\""
                     } else {
-                        "\"$fieldName\"=\"${selectionData.text}\""
+                        "\"$fieldName\"=\"$safeSelectionText\""
                     }
 
-                    // Build the command without "keeper" prefix since we're in the shell
-                    val command = "record-update --record=\"$recordUid\" $formattedField"
+                    // Build the command without "keeper" prefix since we're in the shell.
+        // Classic uses `record-update --record="UID"`; Nested Shared Folders
+        // uses `nsf-record-update -r <UID>` per the nsf-* docs.
+                    val command = if (isDrive) {
+                        "nsf-record-update -r \"$recordUid\" $formattedField"
+                    } else {
+                        "record-update --record=\"$recordUid\" $formattedField"
+                    }
                     
-                    logger.info("Executing record update: $command")
+                    logger.info("Issuing ${command.substringBefore(' ')} for record $recordUid")
                     
                     // Execute with retry logic for reliability
                     val output = KeeperCommandUtils.executeCommandWithRetry(
@@ -113,32 +179,16 @@ class KeeperRecordUpdateAction : AnAction("Update Keeper Record") {
                             retryDelayMs = 2000, // Longer delay between retries
                             logLevel = KeeperCommandUtils.LogLevel.INFO,
                             validation = KeeperCommandUtils.ValidationConfig(
-                                customValidator = { output ->
-                                    // For record-update, empty/minimal output often means success
-                                    // We should REJECT output that contains sync status or errors
-                                    val isSyncStatus = output.contains("Decrypted [") || 
-                                                    output.contains("record(s)") ||
-                                                    output.contains("breachwatch list") ||
-                                                    output.contains("Use \"breachwatch list\" command")
-                                    
-                                    val isErrorMessage = output.contains("error", ignoreCase = true) ||
-                                                    output.contains("failed", ignoreCase = true) ||
-                                                    output.contains("invalid", ignoreCase = true) ||
-                                                    output.contains("not found", ignoreCase = true)
-                                    
-                                    // Success means: no sync status AND no error messages
-                                    // Empty output is actually GOOD for record-update
-                                    val isValid = !isSyncStatus && !isErrorMessage
-                                    
-                                    if (!isValid) {
-                                        logger.debug("Record update validation failed - isSyncStatus: $isSyncStatus, isErrorMessage: $isErrorMessage")
-                                        logger.debug("Output: ${output.take(200)}...")
+                                customValidator = { out ->
+                                    val ok = KeeperRecordOutputValidators.isRecordUpdateSuccess(out)
+                                    if (!ok) {
+                                        logger.debug("Record update validation failed for output: ${out.take(200)}...")
                                     } else {
-                                        logger.debug("Record update validation passed - output length: ${output.length}")
+                                        logger.debug("Record update validation passed - output length: ${out.length}")
                                     }
-                                    
-                                    isValid
-                                }
+                                    ok
+                                },
+                                fatalErrorDetector = KeeperRecordOutputValidators::isFatalError
                             )
                         ),
                         logger
@@ -155,13 +205,24 @@ class KeeperRecordUpdateAction : AnAction("Update Keeper Record") {
                             document.replaceString(selectionData.start!!, selectionData.end!!, keeperReference)
                             FileDocumentManager.getInstance().saveDocument(document)
                         }
+                        val source = if (isDrive) "Nested Shared record" else "Keeper record"
                         Messages.showInfoMessage(
-                            project, 
-                            "Keeper record updated!\n\n$keeperReference", 
+                            project,
+                            "$source updated!\n\n$keeperReference",
                             "Keeper Record Updated"
                         )
                     }, ModalityState.defaultModalityState())
 
+                } catch (fatal: KeeperCommandUtils.FatalCommandException) {
+                    logger.error("Keeper Commander reported a fatal error while updating the record", fatal)
+                    ApplicationManager.getApplication().invokeLater({
+                        showError(
+                            "Keeper Commander rejected the record-update call:\n\n${fatal.message}\n\n" +
+                                "This usually means the installed Keeper Commander build does not support the " +
+                                "command we issued. Try upgrading Commander (`pip install --upgrade keepercommander`).",
+                            project
+                        )
+                    }, ModalityState.defaultModalityState())
                 } catch (ex: Exception) {
                     logger.error("Error updating Keeper record via persistent shell", ex)
                     ApplicationManager.getApplication().invokeLater({

--- a/src/main/kotlin/keepersecurity/action/KeeperRecordUpdateAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperRecordUpdateAction.kt
@@ -70,20 +70,20 @@ class KeeperRecordUpdateAction : AnAction("Update Keeper Record") {
 
         val rawRecordUid = Messages.showInputDialog(
             project,
-            "Enter Keeper record UID:",
-            "Record UID",
+            "Enter Keeper record uid:",
+            "Record Uid",
             null
         )?.trim()
 
         if (rawRecordUid.isNullOrBlank()) {
-            showError("Record UID is required", project)
+            showError("Record uid is required", project)
             return
         }
 
         val recordUid = try {
-            KeeperCliSafety.requireSafe(rawRecordUid, "record UID")
+            KeeperCliSafety.requireSafe(rawRecordUid, "record uid")
         } catch (ex: KeeperCliSafety.UnsafeCliInputException) {
-            showError(ex.message ?: "Record UID is not safe.", project)
+            showError(ex.message ?: "Record uid is not safe.", project)
             return
         }
 
@@ -103,16 +103,16 @@ class KeeperRecordUpdateAction : AnAction("Update Keeper Record") {
             }
             is KeeperRecordValidator.Verdict.NotFound -> {
                 showError(
-                    "Record UID '$recordUid' was not found in your vault. " +
+                    "Record uid '$recordUid' was not found in your vault. " +
                         "Double-check the value (Tools \u2192 Keeper Vault \u2192 Get Keeper Secret " +
-                        "lists every record with its UID).",
+                        "lists every record with its uid).",
                     project
                 )
                 return
             }
             is KeeperRecordValidator.Verdict.Unknown -> {
                 showError(
-                    "Couldn't verify the record UID against your vault " +
+                    "Couldn't verify the record uid against your vault " +
                         "(${verdict.reason}). Make sure Keeper Commander is healthy and try again.",
                     project
                 )

--- a/src/main/kotlin/keepersecurity/action/KeeperSecretAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperSecretAction.kt
@@ -21,6 +21,7 @@ import javax.swing.JScrollPane
 import javax.swing.JTextArea
 
 import keepersecurity.run.KeeperSecureScriptRunner
+import keepersecurity.util.KeeperEnvSafety
 
 class KeeperSecretAction : AnAction("Run Keeper Securely") {
     private val logger = thisLogger()
@@ -49,6 +50,15 @@ class KeeperSecretAction : AnAction("Run Keeper Securely") {
         if (commandInput.isNullOrEmpty()) {
             Messages.showWarningDialog(project, "No command provided, aborting.", "Cancelled")
             return
+        }
+
+        if (KeeperEnvSafety.shouldShowFirstRunWarning()) {
+            Messages.showWarningDialog(
+                project,
+                KeeperEnvSafety.FIRST_RUN_WARNING_MESSAGE,
+                "Run Keeper Securely",
+            )
+            KeeperEnvSafety.markFirstRunWarningShown()
         }
 
         ApplicationManager.getApplication().runWriteAction {

--- a/src/main/kotlin/keepersecurity/model/KeeperModels.kt
+++ b/src/main/kotlin/keepersecurity/model/KeeperModels.kt
@@ -9,6 +9,18 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 
+/**
+ * Parsed Commander payloads for Keeper's two vault models:
+ *
+ *  - **Classic** — the existing folder/permission model (`record-*`, `mkdir`, etc.)
+ *  - **Nested Shared Folders** — the v3 API model (`nsf-*` commands; see
+ *    [Nested Shared Folder command reference](https://docs.keeper.io/keeperpam/commander-cli/command-reference/nested-shared-folder))
+ *
+ * Both models have folders and records (create, update, delete, share, etc.).
+ * Folder rows from `ls --format=json` are tagged with [KeeperFolder.source];
+ * record rows from `list --format json` are tagged with [KeeperRecord.recordCategory].
+ */
+
 @Serializable
 data class KeeperFolder(
     @SerialName("uid") val folderUid: String,
@@ -16,16 +28,118 @@ data class KeeperFolder(
     val type: String? = null,
     val details: String? = null,
     val flags: String? = null,
-    @SerialName("parent_uid") val parentUid: String? = null
-)
+    @SerialName("parent_uid") val parentUid: String? = null,
+    /**
+     * Source discriminator returned by `ls --format=json` in vaults that have
+     * Nested Shared Folders enabled. Commander releases differ:
+     *  - current: `"classic_folder"` / `"nested_share_folder"`
+     *  - older legacy wire values also supported
+     * Missing `source` is treated as classic.
+     */
+    val source: String? = null
+) {
+    companion object {
+        /** Classic vault folder (legacy Commander wire value). */
+        const val SOURCE_LEGACY = "Legacy"
+
+        /** Nested Shared Folder (legacy Commander wire value). */
+        const val SOURCE_KEEPER_DRIVE = "KeeperDrive"
+
+        /** Classic vault folder (newer Commander wire value). */
+        const val SOURCE_CLASSIC_FOLDER = "classic_folder"
+
+        /** Nested Shared Folder (newer Commander wire value). Primary on current builds. */
+        const val SOURCE_NESTED_SHARE_FOLDER = "nested_share_folder"
+
+        /**
+         * Wire values that mean Nested Shared Folder on `ls --format=json -f -R` rows.
+         * Current Commander: [SOURCE_NESTED_SHARE_FOLDER]. Legacy: [SOURCE_KEEPER_DRIVE].
+         */
+        private val NESTED_SHARE_SOURCES = setOf(
+            SOURCE_NESTED_SHARE_FOLDER,
+            SOURCE_KEEPER_DRIVE,
+        )
+
+        /**
+         * Wire values that mean Classic vault folder. Current Commander:
+         * [SOURCE_CLASSIC_FOLDER]. Legacy: [SOURCE_LEGACY]. Null/missing → classic.
+         */
+        private val CLASSIC_SOURCES = setOf(
+            SOURCE_CLASSIC_FOLDER,
+            SOURCE_LEGACY,
+        )
+
+        /** True when [source] identifies a Nested Shared Folder row. */
+        fun isNestedShareSource(source: String?): Boolean =
+            source != null && NESTED_SHARE_SOURCES.any { it.equals(source, ignoreCase = true) }
+
+        /** True when [source] identifies a Classic vault folder row. */
+        fun isClassicSource(source: String?): Boolean =
+            source == null || CLASSIC_SOURCES.any { it.equals(source, ignoreCase = true) }
+    }
+
+    /** True when this folder is a Nested Shared Folder (not Classic Vault). */
+    val isNestedShare: Boolean
+        get() = isNestedShareSource(source)
+
+    /** @see isNestedShare */
+    val isKeeperDrive: Boolean
+        get() = isNestedShare
+}
 
 @Serializable
 data class KeeperRecord(
     @SerialName("record_uid") val recordUid: String,
     val title: String,
     val fields: List<KeeperField>? = null,
-    val custom: List<KeeperCustomField>? = null
-)
+    val custom: List<KeeperCustomField>? = null,
+    /**
+     * Vault-source discriminator on a record row from `list --format json`.
+     * Commander releases differ:
+     *  - current: `"Classic"` / `"Nested"`
+     *  - older legacy wire values also supported
+     * Missing `record_category` is treated as classic.
+     */
+    @SerialName("record_category") val recordCategory: String? = null
+) {
+    companion object {
+        /** Nested Shared record (legacy Commander wire value). */
+        const val CATEGORY_KEEPER_DRIVE = "KeeperDrive"
+
+        /** Nested Shared record (newer Commander wire value). Primary on current builds. */
+        const val CATEGORY_NESTED = "Nested"
+
+        /** Classic-vault record. Same on all Commander builds. */
+        const val CATEGORY_CLASSIC = "Classic"
+
+        /**
+         * Wire values that mean Nested Shared record on `list --format json` rows.
+         * Current Commander: [CATEGORY_NESTED]. Legacy: [CATEGORY_KEEPER_DRIVE].
+         */
+        private val NESTED_SHARE_CATEGORIES = setOf(
+            CATEGORY_NESTED,
+            CATEGORY_KEEPER_DRIVE,
+        )
+
+        /** True when [recordCategory] identifies a Nested Shared record row. */
+        fun isNestedShareCategory(recordCategory: String?): Boolean =
+            recordCategory != null &&
+                NESTED_SHARE_CATEGORIES.any { it.equals(recordCategory, ignoreCase = true) }
+
+        /** True when [recordCategory] identifies a Classic vault record row. */
+        fun isClassicCategory(recordCategory: String?): Boolean =
+            recordCategory == null ||
+                recordCategory.equals(CATEGORY_CLASSIC, ignoreCase = true)
+    }
+
+    /** True when this record lives in a Nested Shared Folder (not Classic Vault). */
+    val isNestedShare: Boolean
+        get() = isNestedShareCategory(recordCategory)
+
+    /** @see isNestedShare */
+    val isKeeperDrive: Boolean
+        get() = isNestedShare
+}
 
 @Serializable
 data class KeeperField(

--- a/src/main/kotlin/keepersecurity/model/KeeperModels.kt
+++ b/src/main/kotlin/keepersecurity/model/KeeperModels.kt
@@ -60,22 +60,9 @@ data class KeeperFolder(
             SOURCE_KEEPER_DRIVE,
         )
 
-        /**
-         * Wire values that mean Classic vault folder. Current Commander:
-         * [SOURCE_CLASSIC_FOLDER]. Legacy: [SOURCE_LEGACY]. Null/missing → classic.
-         */
-        private val CLASSIC_SOURCES = setOf(
-            SOURCE_CLASSIC_FOLDER,
-            SOURCE_LEGACY,
-        )
-
         /** True when [source] identifies a Nested Shared Folder row. */
-        fun isNestedShareSource(source: String?): Boolean =
+        private fun isNestedShareSource(source: String?): Boolean =
             source != null && NESTED_SHARE_SOURCES.any { it.equals(source, ignoreCase = true) }
-
-        /** True when [source] identifies a Classic vault folder row. */
-        fun isClassicSource(source: String?): Boolean =
-            source == null || CLASSIC_SOURCES.any { it.equals(source, ignoreCase = true) }
     }
 
     /** True when this folder is a Nested Shared Folder (not Classic Vault). */
@@ -122,14 +109,9 @@ data class KeeperRecord(
         )
 
         /** True when [recordCategory] identifies a Nested Shared record row. */
-        fun isNestedShareCategory(recordCategory: String?): Boolean =
+        private fun isNestedShareCategory(recordCategory: String?): Boolean =
             recordCategory != null &&
                 NESTED_SHARE_CATEGORIES.any { it.equals(recordCategory, ignoreCase = true) }
-
-        /** True when [recordCategory] identifies a Classic vault record row. */
-        fun isClassicCategory(recordCategory: String?): Boolean =
-            recordCategory == null ||
-                recordCategory.equals(CATEGORY_CLASSIC, ignoreCase = true)
     }
 
     /** True when this record lives in a Nested Shared Folder (not Classic Vault). */

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureRunProfileState.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureRunProfileState.kt
@@ -9,6 +9,8 @@ import com.intellij.execution.filters.TextConsoleBuilderFactory
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
+import com.intellij.openapi.ui.Messages
+import keepersecurity.util.KeeperEnvSafety
 import java.io.File
 
 class KeeperSecureRunProfileState(
@@ -27,6 +29,15 @@ class KeeperSecureRunProfileState(
         } else {
             KeeperSecurePathUtil.resolveToFile(wdPath, base)
         }
+        if (KeeperEnvSafety.shouldShowFirstRunWarning()) {
+            Messages.showWarningDialog(
+                project,
+                KeeperEnvSafety.FIRST_RUN_WARNING_MESSAGE,
+                "Run Keeper Securely",
+            )
+            KeeperEnvSafety.markFirstRunWarningShown()
+        }
+
         val handler = KeeperSecureProcessHandler(project, envFile, workDir, opts.command.orEmpty())
         val console = TextConsoleBuilderFactory.getInstance().createBuilder(project).console
         console.attachToProcess(handler)

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
@@ -9,7 +9,9 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import keepersecurity.service.KeeperShellService
+import keepersecurity.util.KeeperCliSafety
 import keepersecurity.util.KeeperCommandUtils
+import keepersecurity.util.KeeperEnvSafety
 import keepersecurity.util.KeeperJsonUtils
 import keepersecurity.util.KeeperRecordFieldExtractor
 import java.io.File
@@ -55,7 +57,7 @@ object KeeperSecureScriptRunner {
         onProcessStarted: (Process) -> Unit = {},
     ): ExecutionResult {
         val errors = mutableListOf<String>()
-        val keeperPattern = Regex("""keeper://([A-Za-z0-9_-]+)/field/(\S+)""")
+        val keeperPattern = Regex("""keeper://([A-Za-z0-9_-]{22})/field/(\S+)""")
         val keeperRefs = mutableListOf<Triple<String, String, String>>()
 
         try {
@@ -65,8 +67,21 @@ object KeeperSecureScriptRunner {
                 val (key, value) = parts.map { it.trim() }
                 val match = keeperPattern.matchEntire(value)
                 if (match != null) {
+                    KeeperEnvSafety.blockedEnvKeyReason(key)?.let { reason ->
+                        errors.add("Skipped $key: $reason")
+                        logger.warn("Blocked .env key '$key': $reason")
+                        return@forEach
+                    }
                     val uid = match.groupValues[1]
                     val field = match.groupValues[2]
+                    if (!KeeperCliSafety.isValidRecordUid(uid)) {
+                        errors.add(
+                            "Skipped $key: invalid Keeper record UID '$uid' in keeper:// notation " +
+                                "(expected exactly 22 characters: A-Z, a-z, 0-9, _, -)"
+                        )
+                        logger.warn("Invalid keeper:// UID for key '$key': '$uid'")
+                        return@forEach
+                    }
                     keeperRefs.add(Triple(key, uid, field))
                     logger.info("Found Keeper ref: $key -> keeper://$uid/field/$field")
                 }
@@ -77,7 +92,12 @@ object KeeperSecureScriptRunner {
         }
 
         if (keeperRefs.isEmpty()) {
-            logger.warn("No Keeper references found in .env file; running command with no secret injection")
+            val errorList = if (errors.isNotEmpty()) {
+                errors
+            } else {
+                listOf("No Keeper references found in .env file")
+            }
+            return ExecutionResult(0, errorList, "", -1)
         }
 
         val envVars = mutableMapOf<String, String>()
@@ -110,8 +130,16 @@ object KeeperSecureScriptRunner {
                     null
                 }
                 if (!secret.isNullOrEmpty()) {
-                    envVars[key] = secret
-                    logger.info("Injected: $key=****** (${secret.length} chars)")
+                    when (val verdict = KeeperEnvSafety.validateForInjection(key, secret)) {
+                        is KeeperEnvSafety.Verdict.Allowed -> {
+                            envVars[key] = verdict.value
+                            logger.info("Injected: $key=****** (${secret.length} chars)")
+                        }
+                        is KeeperEnvSafety.Verdict.Blocked -> {
+                            errors.add("Skipped $key: ${verdict.reason}")
+                            logger.warn("Blocked env injection for '$key': ${verdict.reason}")
+                        }
+                    }
                 } else {
                     errors.add("Field '$field' not found in Keeper record $uid")
                     logger.warn("Field '$field' not found in record $uid")
@@ -233,6 +261,10 @@ object KeeperSecureScriptRunner {
     }
 
     private fun getKeeperJsonFromShell(uid: String, logger: Logger): String {
+        if (!KeeperCliSafety.isValidRecordUid(uid)) {
+            throw IllegalArgumentException("Invalid Keeper record UID: $uid")
+        }
+        KeeperCliSafety.requireSafe(uid, "record UID")
         val output = KeeperCommandUtils.executeCommandWithRetry(
             "get $uid --format json",
             KeeperCommandUtils.Presets.jsonObject(maxRetries = 3),

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
@@ -194,7 +194,9 @@ object KeeperSecureScriptRunner {
             pb.directory(fileParentDir)
 
             val env = pb.environment()
-            env.putAll(envVars)
+            val subprocessEnv = KeeperEnvSafety.buildSubprocessEnvironment(env, envVars, SystemInfo.isWindows)
+            env.clear()
+            env.putAll(subprocessEnv)
 
             logger.info("Running script with ${envVars.size} injected secrets")
             logger.info("Working directory: ${fileParentDir.absolutePath}")

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureScriptRunner.kt
@@ -76,7 +76,7 @@ object KeeperSecureScriptRunner {
                     val field = match.groupValues[2]
                     if (!KeeperCliSafety.isValidRecordUid(uid)) {
                         errors.add(
-                            "Skipped $key: invalid Keeper record UID '$uid' in keeper:// notation " +
+                            "Skipped $key: invalid Keeper record uid '$uid' in keeper:// notation " +
                                 "(expected exactly 22 characters: A-Z, a-z, 0-9, _, -)"
                         )
                         logger.warn("Invalid keeper:// UID for key '$key': '$uid'")
@@ -262,9 +262,9 @@ object KeeperSecureScriptRunner {
 
     private fun getKeeperJsonFromShell(uid: String, logger: Logger): String {
         if (!KeeperCliSafety.isValidRecordUid(uid)) {
-            throw IllegalArgumentException("Invalid Keeper record UID: $uid")
+            throw IllegalArgumentException("Invalid Keeper record uid: $uid")
         }
-        KeeperCliSafety.requireSafe(uid, "record UID")
+        KeeperCliSafety.requireSafe(uid, "record uid")
         val output = KeeperCommandUtils.executeCommandWithRetry(
             "get $uid --format json",
             KeeperCommandUtils.Presets.jsonObject(maxRetries = 3),

--- a/src/main/kotlin/keepersecurity/service/KeeperShellService.kt
+++ b/src/main/kotlin/keepersecurity/service/KeeperShellService.kt
@@ -1,6 +1,7 @@
 package keepersecurity.service
 
 import com.intellij.openapi.diagnostic.Logger
+import keepersecurity.util.KeeperCliSafety
 import java.io.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
@@ -23,6 +24,15 @@ object KeeperShellService {
     // State management
     private val shellReady = AtomicBoolean(false)
     private val starting = AtomicBoolean(false)
+    /**
+     * Flips to true when [waitForShellInitialization] sees Commander's
+     * interactive password prompt — i.e. the persistent-login token is
+     * missing or expired and Commander is asking for a master password we
+     * can't supply over a piped stdin. Read by callers via [isAuthRequired]
+     * so they can surface a precise "not logged in" message instead of a
+     * generic "shell failed to start".
+     */
+    private val authRequired = AtomicBoolean(false)
     private val commandLock = ReentrantLock()
     
     // Track if this is the first time starting (for better UX messaging)
@@ -687,10 +697,47 @@ object KeeperShellService {
             .joinToString("\n").trim()
     }
     
+    /**
+     * Markers that mean Commander has fallen back to interactive auth
+     * because the persistent-login token is missing/expired. Since our
+     * stdin is a pipe, we cannot satisfy the password prompt — the
+     * Commander process would hang until the (huge) startup timeout. Bail
+     * fast instead and let the caller surface a proper "not logged in"
+     * message.
+     *
+     * IMPORTANT: keep these tight. Commander prints
+     * `Logging in to Keeper as <email>` during a *successful* persistent
+     * login too, so we cannot key off that line. The ones below appear
+     * only when Commander is actually blocked on stdin:
+     *  - "Enter master password" — the literal prompt header
+     *  - "GetPassWarning" / "getpass.py" — Python's getpass module warning
+     *    that fires on every interactive password call against a pipe
+     *  - "Password input may be echoed" — same getpass warning, alt phrasing
+     */
+    private val authRequiredMarkers = listOf(
+        "Enter master password",
+        "GetPassWarning",
+        "getpass.py",
+        "Password input may be echoed"
+    )
+
+    /**
+     * Public read accessor for [authRequired]. Set by
+     * [waitForShellInitialization] when Commander is sitting at a
+     * password prompt. Use this to distinguish "shell crashed / CLI
+     * missing" from "user just needs to `keeper login --persistent` once".
+     */
+    fun isAuthRequired(): Boolean = authRequired.get()
+
     private fun waitForShellInitialization(): Boolean {
         val startTime = System.currentTimeMillis()
         val timeoutMs = getShellInitTimeout()
-        
+
+        // Reset before every initialization attempt — the previous attempt
+        // may have flipped this on, but the caller is now retrying with
+        // (hopefully) a refreshed persistent-login config.
+        authRequired.set(false)
+
         logger.info("Waiting for Keeper shell to be ready (${getTimeoutDescription()})...")
         logger.info("Process created successfully, PID: ${process?.pid()}")
         
@@ -699,7 +746,20 @@ object KeeperShellService {
         while (System.currentTimeMillis() - startTime < timeoutMs) {
             bufferLock.withLock {
                 val currentOutput = outputBuffer.toString()
-                
+
+                // Short-circuit on Commander's interactive password prompt.
+                // There's no point waiting the full timeout — without a TTY,
+                // we can't possibly satisfy the prompt.
+                if (authRequiredMarkers.any { currentOutput.contains(it, ignoreCase = true) }) {
+                    logger.warn(
+                        "Commander is asking for a master password (persistent login " +
+                            "missing or expired). Bailing out fast; the user must run " +
+                            "`keeper login --persistent` once in a terminal."
+                    )
+                    authRequired.set(true)
+                    return false
+                }
+
                 if (isShellReady(currentOutput)) {
                     logger.info("Shell appears ready based on output content")
                     
@@ -779,12 +839,13 @@ object KeeperShellService {
             currentCommand.set(execution)
             
             try {
-                logger.info("Executing command: $command")
-                
+                logger.info("Executing command verb: ${command.substringBefore(' ')} (length=${command.length})")
+
                 bufferLock.withLock {
                     outputBuffer.setLength(0)
                 }
-                
+
+                KeeperCliSafety.assertSingleLine(command)
                 writer?.apply {
                     write(command)
                     write("\n")

--- a/src/main/kotlin/keepersecurity/ui/KeeperListPickerDialog.kt
+++ b/src/main/kotlin/keepersecurity/ui/KeeperListPickerDialog.kt
@@ -3,7 +3,6 @@ package keepersecurity.ui
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.CollectionListModel
-import com.intellij.ui.DocumentAdapter
 import com.intellij.ui.SearchTextField
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBList
@@ -24,6 +23,7 @@ import javax.swing.ListCellRenderer
 import javax.swing.ListSelectionModel
 import javax.swing.SwingConstants
 import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
 
 /** Vault-model badge shown beside each folder or record in the searchable picker. */
 enum class KeeperVaultBadge(val label: String) {
@@ -43,7 +43,7 @@ data class KeeperListPickerItem(
     fun matchesSearch(query: String): Boolean {
         if (query.isEmpty()) return true
         if (label.contains(query, ignoreCase = true)) return true
-        return badge?.label?.contains(query, ignoreCase = true) == true
+        return badge?.label?.contains(query, ignoreCase = true) ?: false
     }
 }
 
@@ -112,7 +112,7 @@ object KeeperListPickerDialog {
 
     private class ListPickerDialog(
         project: Project,
-        dialogTitle: String,
+        private val dialogTitle: String,
         private val message: String,
         private val options: List<KeeperListPickerItem>,
         private val initial: KeeperListPickerItem?,
@@ -145,8 +145,12 @@ object KeeperListPickerDialog {
                 }
             })
 
-            search.textEditor.document.addDocumentListener(object : DocumentAdapter() {
-                override fun textChanged(e: DocumentEvent) {
+            search.textEditor.document.addDocumentListener(object : DocumentListener {
+                override fun insertUpdate(e: DocumentEvent) = onTextChanged()
+                override fun removeUpdate(e: DocumentEvent) = onTextChanged()
+                override fun changedUpdate(e: DocumentEvent) = onTextChanged()
+
+                private fun onTextChanged() {
                     val query = search.text.trim()
                     val filtered = options.filter { it.matchesSearch(query) }
                     listModel.replaceAll(filtered)
@@ -205,12 +209,11 @@ object KeeperListPickerDialog {
         ): Component {
             nameLabel.text = value?.label.orEmpty()
 
-            val badge = value?.badge
-            if (badge != null) {
+            value?.badge?.let { badge ->
                 badgeLabel.isVisible = true
                 badgeLabel.text = badge.label
                 applyBadgeColors(badgeLabel, badge, isSelected, list)
-            } else {
+            } ?: run {
                 badgeLabel.isVisible = false
             }
 

--- a/src/main/kotlin/keepersecurity/ui/KeeperListPickerDialog.kt
+++ b/src/main/kotlin/keepersecurity/ui/KeeperListPickerDialog.kt
@@ -1,0 +1,260 @@
+package keepersecurity.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.CollectionListModel
+import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.SearchTextField
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JList
+import javax.swing.JPanel
+import javax.swing.ListCellRenderer
+import javax.swing.ListSelectionModel
+import javax.swing.SwingConstants
+import javax.swing.event.DocumentEvent
+
+/** Vault-model badge shown beside each folder or record in the searchable picker. */
+enum class KeeperVaultBadge(val label: String) {
+    CLASSIC("Classic"),
+    NESTED("Nested"),
+}
+
+/**
+ * One row in [KeeperListPickerDialog]. [label] is the folder or record name;
+ * [badge] identifies Classic vs Nested Shared Folder when both vault models
+ * appear in the same list.
+ */
+data class KeeperListPickerItem(
+    val label: String,
+    val badge: KeeperVaultBadge? = null,
+) {
+    fun matchesSearch(query: String): Boolean {
+        if (query.isEmpty()) return true
+        if (label.contains(query, ignoreCase = true)) return true
+        return badge?.label?.contains(query, ignoreCase = true) == true
+    }
+}
+
+/**
+ * Wide, resizable, searchable single-select list picker used by Keeper
+ * actions in place of `Messages.showEditableChooseDialog`. The platform
+ * helper is fine for short labels but truncates long record or folder titles
+ * because it sizes to the *narrower* of its column metric and the screen width.
+ *
+ * Folder and record pickers pass [KeeperListPickerItem] rows with a Classic /
+ * Nested badge on the right so users can tell which vault model each entry
+ * belongs to without cluttering the primary label.
+ *
+ * Must be invoked on the EDT — same calling-convention as
+ * `Messages.showEditableChooseDialog`.
+ */
+object KeeperListPickerDialog {
+
+    /**
+     * Show the picker and return the chosen entry, or `null` if the user
+     * cancelled / dismissed the dialog.
+     */
+    fun pick(
+        project: Project,
+        title: String,
+        message: String,
+        options: List<String>,
+        initialSelection: String? = null,
+        preferredWidth: Int = 640,
+        preferredHeight: Int = 420,
+    ): String? = pickItem(
+        project = project,
+        title = title,
+        message = message,
+        options = options.map { KeeperListPickerItem(it) },
+        initialSelection = initialSelection?.let { KeeperListPickerItem(it) },
+        preferredWidth = preferredWidth,
+        preferredHeight = preferredHeight,
+    )?.label
+
+    /**
+     * Show the picker with optional Classic / Nested badges and return the
+     * chosen [KeeperListPickerItem], or `null` if cancelled.
+     */
+    fun pickItem(
+        project: Project,
+        title: String,
+        message: String,
+        options: List<KeeperListPickerItem>,
+        initialSelection: KeeperListPickerItem? = null,
+        preferredWidth: Int = 640,
+        preferredHeight: Int = 420,
+    ): KeeperListPickerItem? {
+        if (options.isEmpty()) return null
+        val dialog = ListPickerDialog(
+            project = project,
+            dialogTitle = title,
+            message = message,
+            options = options,
+            initial = initialSelection,
+            prefW = preferredWidth,
+            prefH = preferredHeight,
+        )
+        return if (dialog.showAndGet()) dialog.chosenValue else null
+    }
+
+    private class ListPickerDialog(
+        project: Project,
+        dialogTitle: String,
+        private val message: String,
+        private val options: List<KeeperListPickerItem>,
+        private val initial: KeeperListPickerItem?,
+        private val prefW: Int,
+        private val prefH: Int,
+    ) : DialogWrapper(project, true) {
+
+        private val listModel = CollectionListModel(options)
+        private val list = JBList(listModel).apply {
+            cellRenderer = VaultBadgeListCellRenderer()
+        }
+        private val search = SearchTextField()
+
+        init {
+            title = dialogTitle
+            list.selectionMode = ListSelectionModel.SINGLE_SELECTION
+
+            val initialIndex = initial?.let { options.indexOf(it) }?.takeIf { it >= 0 } ?: 0
+            list.selectedIndex = initialIndex
+
+            list.addListSelectionListener {
+                isOKActionEnabled = list.selectedValue != null
+            }
+
+            list.addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    if (e.clickCount == 2 && list.selectedValue != null) {
+                        doOKAction()
+                    }
+                }
+            })
+
+            search.textEditor.document.addDocumentListener(object : DocumentAdapter() {
+                override fun textChanged(e: DocumentEvent) {
+                    val query = search.text.trim()
+                    val filtered = options.filter { it.matchesSearch(query) }
+                    listModel.replaceAll(filtered)
+                    list.selectedIndex = if (filtered.isNotEmpty()) 0 else -1
+                    isOKActionEnabled = list.selectedValue != null
+                }
+            })
+
+            init()
+        }
+
+        override fun getPreferredFocusedComponent(): JComponent = search
+
+        override fun createCenterPanel(): JComponent {
+            val panel = JPanel(BorderLayout(0, JBUI.scale(6)))
+            panel.preferredSize = Dimension(JBUI.scale(prefW), JBUI.scale(prefH))
+
+            if (message.isNotEmpty()) {
+                val north = JPanel(BorderLayout(0, JBUI.scale(6)))
+                north.add(JLabel(message), BorderLayout.NORTH)
+                north.add(search, BorderLayout.SOUTH)
+                panel.add(north, BorderLayout.NORTH)
+            } else {
+                panel.add(search, BorderLayout.NORTH)
+            }
+            panel.add(JBScrollPane(list), BorderLayout.CENTER)
+            return panel
+        }
+
+        val chosenValue: KeeperListPickerItem?
+            get() = list.selectedValue
+    }
+
+    private class VaultBadgeListCellRenderer : JPanel(BorderLayout(JBUI.scale(8), 0)),
+        ListCellRenderer<KeeperListPickerItem> {
+
+        private val nameLabel = JBLabel()
+        private val badgeLabel = JBLabel("", SwingConstants.CENTER).apply {
+            border = JBUI.Borders.empty(1, JBUI.scale(6))
+            isOpaque = true
+            font = font.deriveFont(font.size2D - 1f)
+        }
+
+        init {
+            border = JBUI.Borders.empty(JBUI.scale(4), JBUI.scale(8))
+            add(nameLabel, BorderLayout.CENTER)
+            add(badgeLabel, BorderLayout.EAST)
+        }
+
+        override fun getListCellRendererComponent(
+            list: JList<out KeeperListPickerItem>,
+            value: KeeperListPickerItem?,
+            index: Int,
+            isSelected: Boolean,
+            cellHasFocus: Boolean,
+        ): Component {
+            nameLabel.text = value?.label.orEmpty()
+
+            val badge = value?.badge
+            if (badge != null) {
+                badgeLabel.isVisible = true
+                badgeLabel.text = badge.label
+                applyBadgeColors(badgeLabel, badge, isSelected, list)
+            } else {
+                badgeLabel.isVisible = false
+            }
+
+            background = if (isSelected) list.selectionBackground else list.background
+            nameLabel.foreground = if (isSelected) list.selectionForeground else list.foreground
+            isOpaque = true
+            return this
+        }
+
+        private fun applyBadgeColors(
+            label: JBLabel,
+            badge: KeeperVaultBadge,
+            isSelected: Boolean,
+            list: JList<out KeeperListPickerItem>,
+        ) {
+            if (isSelected) {
+                label.background = list.selectionForeground
+                label.foreground = list.selectionBackground
+                return
+            }
+            val (background, foreground) = when (badge) {
+                KeeperVaultBadge.CLASSIC -> Pair(
+                    UIUtil.getPanelBackground().brighter(),
+                    UIUtil.getLabelDisabledForeground(),
+                )
+                KeeperVaultBadge.NESTED -> Pair(
+                    nestedBadgeBackground(),
+                    nestedBadgeForeground(),
+                )
+            }
+            label.background = background
+            label.foreground = foreground
+        }
+
+        private fun nestedBadgeBackground(): Color =
+            JBUI.CurrentTheme.Link.linkColor().let { link ->
+                Color(
+                    (link.red + 255 * 4) / 5,
+                    (link.green + 255 * 4) / 5,
+                    (link.blue + 255 * 4) / 5,
+                    255,
+                )
+            }
+
+        private fun nestedBadgeForeground(): Color = JBUI.CurrentTheme.Link.linkColor()
+    }
+}

--- a/src/main/kotlin/keepersecurity/ui/KeeperListPickerDialog.kt
+++ b/src/main/kotlin/keepersecurity/ui/KeeperListPickerDialog.kt
@@ -34,11 +34,13 @@ enum class KeeperVaultBadge(val label: String) {
 /**
  * One row in [KeeperListPickerDialog]. [label] is the folder or record name;
  * [badge] identifies Classic vs Nested Shared Folder when both vault models
- * appear in the same list.
+ * appear in the same list. [id] carries the folder or record uid so duplicate
+ * display names resolve to the row the user actually clicked.
  */
 data class KeeperListPickerItem(
     val label: String,
     val badge: KeeperVaultBadge? = null,
+    val id: String? = null,
 ) {
     fun matchesSearch(query: String): Boolean {
         if (query.isEmpty()) return true

--- a/src/main/kotlin/keepersecurity/util/KeeperCliSafety.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperCliSafety.kt
@@ -1,0 +1,67 @@
+package keepersecurity.util
+
+/**
+ * CLI-safety helpers shared by every action that pipes user-controlled
+ * strings into the persistent Commander shell.
+ *
+ * The persistent shell reads stdin one line at a time, so an embedded
+ * `\n`, `\r`, or `\x00` in any concatenated argument splits the write
+ * into two (or more) Commander commands. We refuse those characters at
+ * the input boundary and again at the shell-write boundary as
+ * defense-in-depth.
+ */
+object KeeperCliSafety {
+
+    /**
+     * Keeper record UID in `keeper://<uid>/field/...` notation: URL-safe
+     * Base64, exactly 22 characters ([A-Za-z0-9_-]).
+     */
+    val KEEPER_RECORD_UID: Regex = Regex("""^[A-Za-z0-9_-]{22}$""")
+
+    /** Characters that terminate or null-break a Commander command line. */
+    private const val FORBIDDEN = "\r\n\u0000"
+
+    /** True when [uid] matches [KEEPER_RECORD_UID]. */
+    fun isValidRecordUid(uid: String): Boolean = KEEPER_RECORD_UID.matches(uid)
+
+    /**
+     * Thrown when a user-supplied string or an assembled command
+     * contains a forbidden control character. The message is suitable
+     * for surfacing in `Messages.showErrorDialog`.
+     */
+    class UnsafeCliInputException(message: String) : RuntimeException(message)
+
+    /**
+     * Validate a user-supplied value before it gets concatenated into a
+     * Commander command. Returns the value unchanged on success, throws
+     * [UnsafeCliInputException] when the value contains `\r`, `\n`, or
+     * `\x00`.
+     */
+    fun requireSafe(value: String, fieldLabel: String): String {
+        if (value.any { it in FORBIDDEN }) {
+            throw UnsafeCliInputException(
+                "The $fieldLabel contains a newline or null byte. " +
+                    "Keeper records do not support multi-line values from this " +
+                    "action — please remove line breaks (and any other control " +
+                    "characters) and try again. For multi-line content use the " +
+                    "Keeper web vault or the `note` field type."
+            )
+        }
+        return value
+    }
+
+    /**
+     * Last-line-of-defense check at the shell-write boundary. Refuses
+     * to write any string that still contains a forbidden character at
+     * the point where it would reach `keeper shell` stdin.
+     */
+    fun assertSingleLine(command: String) {
+        if (command.any { it in FORBIDDEN }) {
+            throw UnsafeCliInputException(
+                "Refusing to write a multi-line command to the Keeper shell. " +
+                    "This is a safety check; an upstream input boundary should " +
+                    "have already rejected this value."
+            )
+        }
+    }
+}

--- a/src/main/kotlin/keepersecurity/util/KeeperCliSafety.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperCliSafety.kt
@@ -24,6 +24,14 @@ object KeeperCliSafety {
     /** True when [uid] matches [KEEPER_RECORD_UID]. */
     fun isValidRecordUid(uid: String): Boolean = KEEPER_RECORD_UID.matches(uid)
 
+    /** Escape `\` and `"` before embedding a value in a double-quoted CLI argument. */
+    fun escapeDoubleQuoted(value: String): String =
+        value.replace("\\", "\\\\").replace("\"", "\\\"")
+
+    /** Escape `'` for embedding in a single-quoted CLI argument (POSIX shell rules). */
+    fun escapeSingleQuoted(value: String): String =
+        value.replace("'", "'\\''")
+
     /**
      * Thrown when a user-supplied string or an assembled command
      * contains a forbidden control character. The message is suitable

--- a/src/main/kotlin/keepersecurity/util/KeeperCommandUtils.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperCommandUtils.kt
@@ -26,8 +26,23 @@ object KeeperCommandUtils {
         val requiredContent: String? = null,
         val forbiddenContent: String? = null,
         val minLength: Int = 0,
-        val customValidator: ((String) -> Boolean)? = null
+        val customValidator: ((String) -> Boolean)? = null,
+        /**
+         * Optional predicate that, when it matches, short-circuits the retry
+         * loop with a [FatalCommandException] carrying the actual CLI
+         * output. Use this for failures that won't change between attempts
+         * (e.g. Commander Python exceptions, "unknown command", "not logged
+         * in") so the user sees the real error message instead of
+         * "validation failed after N attempts".
+         */
+        val fatalErrorDetector: ((String) -> Boolean)? = null
     )
+
+    /**
+     * Thrown when a command's output matches [ValidationConfig.fatalErrorDetector].
+     * Carries the CLI output so the calling action can surface it verbatim.
+     */
+    class FatalCommandException(val output: String, message: String) : RuntimeException(message)
     
     /**
      * Log level for retry operations
@@ -46,10 +61,11 @@ object KeeperCommandUtils {
         
         for (attempt in 1..config.maxRetries) {
             try {
+                val commandVerb = command.substringBefore(' ')
                 when (config.logLevel) {
-                    LogLevel.DEBUG -> logger?.debug("Attempt $attempt/${config.maxRetries}: $command")
-                    LogLevel.INFO -> logger?.info("Attempt $attempt/${config.maxRetries}: $command")
-                    LogLevel.WARN -> logger?.warn("Attempt $attempt/${config.maxRetries}: $command")
+                    LogLevel.DEBUG -> logger?.debug("Attempt $attempt/${config.maxRetries}: $commandVerb")
+                    LogLevel.INFO -> logger?.info("Attempt $attempt/${config.maxRetries}: $commandVerb")
+                    LogLevel.WARN -> logger?.warn("Attempt $attempt/${config.maxRetries}: $commandVerb")
                 }
                 
                 val output = KeeperShellService.executeCommand(command, config.timeoutSeconds)
@@ -74,6 +90,22 @@ object KeeperCommandUtils {
                 
                 // Apply custom validation if configured
                 if (config.validation != null) {
+                    // Short-circuit on fatal Commander errors — retrying a
+                    // missing-module / "unknown command" call just wastes the
+                    // user's time and buries the real CLI message under our
+                    // "validation failed after N attempts" wrapper.
+                    config.validation.fatalErrorDetector?.let { isFatal ->
+                        if (isFatal(output)) {
+                            val excerpt = output.lineSequence()
+                                .map { it.trim() }
+                                .firstOrNull { it.isNotBlank() }
+                                ?.take(300)
+                                ?: output.take(300)
+                            logger?.warn("Fatal Commander error detected, aborting retries: $excerpt")
+                            throw FatalCommandException(output, excerpt)
+                        }
+                    }
+
                     if (!isValidOutput(output, config.validation, logger)) {
                         if (attempt < config.maxRetries) {
                             logger?.info("Validation failed, retrying in ${config.retryDelayMs}ms...")
@@ -93,6 +125,9 @@ object KeeperCommandUtils {
                 
                 return output
                 
+            } catch (fatal: FatalCommandException) {
+                // Hard Commander failures bypass the retry loop entirely.
+                throw fatal
             } catch (ex: Exception) {
                 lastException = ex
                 logger?.warn("Attempt $attempt failed: ${ex.message}")
@@ -109,6 +144,32 @@ object KeeperCommandUtils {
         throw lastException ?: RuntimeException("Command failed after ${config.maxRetries} attempts")
     }
     
+    /**
+     * Best-effort `sync-down` against the persistent Commander shell.
+     *
+     * The plugin keeps its own long-lived Commander process (see
+     * `KeeperShellService`), which holds a per-session vault cache. Records
+     * or folders that were created in a separate terminal session — even
+     * after the user runs `sync-down` there — won't be visible to the
+     * plugin's shell until *it* also syncs. Listing actions that drive
+     * picker dialogs should call this before fetching so the picker
+     * reflects the live vault.
+     *
+     * Failures are swallowed and logged: a failed sync should never block
+     * the user from at least attempting the listing call that follows
+     * (the stale cache is still better than nothing).
+     */
+    fun syncDownBestEffort(logger: Logger? = null, timeoutSeconds: Long = 30) {
+        try {
+            val startedAt = System.currentTimeMillis()
+            KeeperShellService.executeCommand("sync-down", timeoutSeconds)
+            val elapsed = System.currentTimeMillis() - startedAt
+            logger?.info("sync-down completed in ${elapsed}ms")
+        } catch (ex: Exception) {
+            logger?.warn("sync-down failed (continuing with stale cache): ${ex.message}")
+        }
+    }
+
     /**
      * Validate command output based on configuration
      */

--- a/src/main/kotlin/keepersecurity/util/KeeperEnvSafety.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperEnvSafety.kt
@@ -1,0 +1,120 @@
+package keepersecurity.util
+
+import com.intellij.ide.util.PropertiesComponent
+
+/**
+ * Safety checks for **Run Keeper Securely**: vault-backed values are merged
+ * into the spawned process environment via [ProcessBuilder], so both the
+ * `.env` key and the fetched field value must be validated before injection.
+ *
+ * Shared Keeper records can supply malicious field content (e.g.
+ * `--require=./pwn.js` in a Notes field referenced as `NODE_OPTIONS`), which
+ * interpreters treat as code-load hooks. We block known hook variable names
+ * and reject values that look like interpreter directives or shell injection.
+ */
+object KeeperEnvSafety {
+
+    const val FIRST_RUN_WARNING_PROPERTY = "keeper.runSecurely.envWarningShown"
+
+    const val FIRST_RUN_WARNING_MESSAGE =
+        "Run Keeper Securely resolves keeper:// references from your .env file " +
+            "and injects the fetched values into the environment of the command you run.\n\n" +
+            "Only reference Keeper records you trust. Secrets from shared folders " +
+            "can influence what runs in your process.\n\n" +
+            "Interpreter hook variables (NODE_OPTIONS, LD_PRELOAD, PYTHONPATH, etc.) " +
+            "are blocked automatically."
+
+    private val EXACT_BLOCKED_KEYS = setOf(
+        "BASH_ENV",
+        "BROWSER",
+        "EDITOR",
+        "ENV",
+        "GIT_EXTERNAL_DIFF",
+        "GIT_SSH_COMMAND",
+        "JAVA_TOOL_OPTIONS",
+        "LD_LIBRARY_PATH",
+        "LD_PRELOAD",
+        "MANPAGER",
+        "NODE_OPTIONS",
+        "PAGER",
+        "PERL5OPT",
+        "PROMPT_COMMAND",
+        "PS0",
+        "PS1",
+        "PS2",
+        "PS4",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "RUBYOPT",
+        "VISUAL",
+        "_JAVA_OPTIONS",
+    )
+
+    /** Characters that must not appear in injected env values. */
+    private const val FORBIDDEN_VALUE_CHARS = "\r\n\u0000"
+
+    sealed class Verdict {
+        data class Allowed(val key: String, val value: String) : Verdict()
+        data class Blocked(val key: String, val reason: String) : Verdict()
+    }
+
+    fun shouldShowFirstRunWarning(): Boolean =
+        !PropertiesComponent.getInstance().getBoolean(FIRST_RUN_WARNING_PROPERTY, false)
+
+    fun markFirstRunWarningShown() {
+        PropertiesComponent.getInstance().setValue(FIRST_RUN_WARNING_PROPERTY, true)
+    }
+
+    /**
+     * Validate an env key from the `.env` file before fetching the Keeper secret.
+     * Returns a human-readable rejection reason, or `null` when the key is allowed.
+     */
+    fun blockedEnvKeyReason(key: String): String? {
+        val trimmed = key.trim()
+        if (trimmed.isEmpty()) return "environment variable name is empty"
+
+        val upper = trimmed.uppercase()
+        if (upper in EXACT_BLOCKED_KEYS) {
+            return "'$trimmed' is a blocked interpreter or shell hook variable"
+        }
+        if (upper.startsWith("DYLD_")) {
+            return "'$trimmed' is a blocked dynamic-linker hook (DYLD_*)"
+        }
+        if (upper.endsWith("_OPTIONS")) {
+            return "'$trimmed' matches the blocked *_OPTIONS hook pattern"
+        }
+        if (upper.endsWith("_DEBUGGER")) {
+            return "'$trimmed' matches the blocked *_DEBUGGER hook pattern"
+        }
+        return null
+    }
+
+    /**
+     * Validate a fetched vault value before it is written into the process env.
+     * Returns a human-readable rejection reason, or `null` when the value is allowed.
+     */
+    fun blockedEnvValueReason(value: String): String? {
+        if (value.any { it in FORBIDDEN_VALUE_CHARS }) {
+            return "value contains control characters (newline or null byte)"
+        }
+        if (value.startsWith("-")) {
+            return "value looks like an interpreter flag (starts with '-')"
+        }
+        if (value.contains("$(")) {
+            return "value contains command substitution (\$(...))"
+        }
+        if (value.contains('`')) {
+            return "value contains command substitution (backticks)"
+        }
+        return null
+    }
+
+    /**
+     * Combined key + value check used at injection time.
+     */
+    fun validateForInjection(key: String, value: String): Verdict {
+        blockedEnvKeyReason(key)?.let { return Verdict.Blocked(key, it) }
+        blockedEnvValueReason(value)?.let { return Verdict.Blocked(key, it) }
+        return Verdict.Allowed(key, value)
+    }
+}

--- a/src/main/kotlin/keepersecurity/util/KeeperEnvSafety.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperEnvSafety.kt
@@ -97,9 +97,6 @@ object KeeperEnvSafety {
         if (value.any { it in FORBIDDEN_VALUE_CHARS }) {
             return "value contains control characters (newline or null byte)"
         }
-        if (value.startsWith("-")) {
-            return "value looks like an interpreter flag (starts with '-')"
-        }
         if (value.contains("$(")) {
             return "value contains command substitution (\$(...))"
         }
@@ -116,5 +113,33 @@ object KeeperEnvSafety {
         blockedEnvKeyReason(key)?.let { return Verdict.Blocked(key, it) }
         blockedEnvValueReason(value)?.let { return Verdict.Blocked(key, it) }
         return Verdict.Allowed(key, value)
+    }
+
+    private val PRESERVED_UNIX_ENV_KEYS = listOf(
+        "PATH", "HOME", "USER", "SHELL", "LANG", "LC_ALL", "TMPDIR",
+    )
+
+    private val PRESERVED_WINDOWS_ENV_KEYS = listOf(
+        "PATH", "USERPROFILE", "SystemRoot", "TEMP", "TMP", "ComSpec",
+    )
+
+    /**
+     * Build the subprocess environment for Run Keeper Securely: validated vault
+     * secrets plus a minimal whitelist from the parent IDE process. The full
+     * inherited env is not copied — hook variables already present in the IDE
+     * (NODE_OPTIONS, LD_PRELOAD, DYLD_*, etc.) must not leak into the child.
+     */
+    fun buildSubprocessEnvironment(
+        inherited: Map<String, String>,
+        injected: Map<String, String>,
+        isWindows: Boolean,
+    ): Map<String, String> {
+        val env = linkedMapOf<String, String>()
+        injected.forEach { (k, v) -> env[k] = v }
+        val preservedKeys = if (isWindows) PRESERVED_WINDOWS_ENV_KEYS else PRESERVED_UNIX_ENV_KEYS
+        preservedKeys.forEach { key ->
+            inherited[key]?.let { env[key] = it }
+        }
+        return env
     }
 }

--- a/src/main/kotlin/keepersecurity/util/KeeperFolderValidator.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperFolderValidator.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import keepersecurity.model.KeeperFolder
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 /**
@@ -45,7 +44,7 @@ object KeeperFolderValidator {
         ) : Verdict()
 
         /** UUID is not present in the current `ls` payload. */
-        object Missing : Verdict()
+        data object Missing : Verdict()
 
         /**
          * UUID exists but lives in the *other* vault — e.g. the project

--- a/src/main/kotlin/keepersecurity/util/KeeperFolderValidator.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperFolderValidator.kt
@@ -1,0 +1,174 @@
+package keepersecurity.util
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import keepersecurity.model.KeeperFolder
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+/**
+ * Verifies that a previously-saved Keeper folder UUID still corresponds
+ * to a real folder in the user's vault before we issue
+ * `record-add --folder=<uuid>` / `nsf-record-add --folder <uuid>` with it.
+ *
+ * The validator deliberately re-uses the *same* `ls --format=json -f -R`
+ * call that [keepersecurity.action.KeeperFolderSelectAction] makes when
+ * populating the picker. Using one source of truth means:
+ *
+ *  1. A folder visible in the picker is also "valid" to the validator —
+ *     no risk of the two sides disagreeing on what "exists" means.
+ *  2. We don't need a per-folder `get <uuid> --format json` round-trip,
+ *     which would also need a custom parser since Commander's folder-`get`
+ *     JSON doesn't match its record-`get` JSON shape (see KeeperJsonUtils
+ *     heuristics — they assume record fields).
+ *  3. The classic ↔ Nested Shared Folder *category* of each folder is already
+ *     attached to the picker payload via [KeeperFolder.isKeeperDrive], so
+ *     we can also detect "saved as classic but is actually a Nested Shared Folder
+ *     folder" mismatches in the same pass.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+object KeeperFolderValidator {
+
+    /** Which slot we're validating. */
+    enum class ExpectedKind { CLASSIC, DRIVE }
+
+    /** Outcome of a single [verifySavedFolder] / [verifyBlocking] call. */
+    sealed class Verdict {
+        /** UUID is still present and matches the expected slot. */
+        data class Valid(
+            val uuid: String,
+            val name: String,
+            val isDrive: Boolean
+        ) : Verdict()
+
+        /** UUID is not present in the current `ls` payload. */
+        object Missing : Verdict()
+
+        /**
+         * UUID exists but lives in the *other* vault — e.g. the project
+         * has a classic UUID saved but the folder is actually a Keeper
+         * Drive folder. The caller should clear the stale slot.
+         */
+        data class Mismatch(
+            val actualKind: ExpectedKind,
+            val name: String
+        ) : Verdict()
+
+        /**
+         * The CLI lookup itself failed (shell unhealthy, network down,
+         * etc.). Callers should usually fail-soft and let the downstream
+         * `record-add` raise the real error rather than wiping a possibly
+         * valid UUID just because the IDE couldn't reach Commander right
+         * now.
+         */
+        data class Unknown(val reason: String) : Verdict()
+    }
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        allowTrailingComma = true
+    }
+
+    private val logger: Logger = thisLogger()
+
+    /**
+     * Run the verification under a small modal progress dialog so the EDT
+     * stays responsive while Commander walks the vault. Safe to call from
+     * the EDT.
+     *
+     * @param project   Anchor project for the progress modal.
+     * @param uuid      The UUID we have saved in [PropertiesComponent].
+     * @param expected  Which slot it was saved under.
+     */
+    fun verifySavedFolder(project: Project, uuid: String, expected: ExpectedKind): Verdict {
+        val verdictHolder = arrayOf<Verdict>(Verdict.Unknown("not run"))
+        ProgressManager.getInstance().runProcessWithProgressSynchronously(
+            {
+                val indicator = ProgressManager.getInstance().progressIndicator
+                indicator?.text = "Refreshing Keeper vault\u2026"
+                verdictHolder[0] = verifyBlocking(uuid, expected) { phase ->
+                    indicator?.text = phase
+                }
+            },
+            "Verifying saved Keeper folder\u2026",
+            false,
+            project
+        )
+        return verdictHolder[0]
+    }
+
+    /**
+     * Blocking variant. Intended for non-UI callers (e.g. unit tests or
+     * code already running on a background thread). The body must not be
+     * called from the EDT — it issues a synchronous `sync-down` + `ls`
+     * against the persistent shell.
+     *
+     * **A `sync-down` is required before the `ls`**: without it the
+     * plugin's persistent shell happily lists a folder that was deleted
+     * from another session (e.g. the user's standalone `keeper shell`
+     * terminal), then the *Add* dispatch issues `record-add --folder`
+     * with that ghost UUID — Commander reports local "success" but
+     * nothing materialises in the actual vault. The cost is one extra
+     * round-trip per Add / Generate, which the existing
+     * `KeeperFolderSelectAction` already accepts when it populates the
+     * picker.
+     *
+     * @param onPhase optional progress hook; invoked with a short
+     *                human-readable status string before each phase
+     *                (sync, then ls).
+     */
+    internal fun verifyBlocking(
+        uuid: String,
+        expected: ExpectedKind,
+        onPhase: (String) -> Unit = {}
+    ): Verdict {
+        if (uuid.isBlank()) return Verdict.Unknown("empty uuid")
+
+        onPhase("Refreshing Keeper vault\u2026")
+        KeeperCommandUtils.syncDownBestEffort(logger)
+
+        onPhase("Verifying saved Keeper folder\u2026")
+        val output = try {
+            KeeperCommandUtils.executeCommandWithRetry(
+                "ls --format=json -f -R",
+                KeeperCommandUtils.Presets.jsonArray(maxRetries = 2, timeoutSeconds = 60),
+                logger
+            )
+        } catch (ex: Exception) {
+            logger.warn("Could not fetch folder list while verifying saved UUID '$uuid': ${ex.message}")
+            return Verdict.Unknown(ex.message ?: ex.javaClass.simpleName)
+        }
+
+        val folders = try {
+            val jsonText = KeeperJsonUtils.extractJsonArray(output, logger)
+            json.decodeFromString<List<KeeperFolder>>(jsonText)
+        } catch (ex: Exception) {
+            logger.warn("Could not parse folder list while verifying saved UUID '$uuid': ${ex.message}")
+            return Verdict.Unknown(ex.message ?: ex.javaClass.simpleName)
+        }
+
+        return classify(folders, uuid, expected)
+    }
+
+    /**
+     * Pure classifier extracted so the parsing-only branch can be tested
+     * without spinning up [KeeperShellService] / [ProgressManager].
+     */
+    internal fun classify(
+        folders: List<KeeperFolder>,
+        uuid: String,
+        expected: ExpectedKind
+    ): Verdict {
+        val match = folders.firstOrNull { it.folderUid == uuid } ?: return Verdict.Missing
+        val actual = if (match.isKeeperDrive) ExpectedKind.DRIVE else ExpectedKind.CLASSIC
+        return if (actual == expected) {
+            Verdict.Valid(uuid = uuid, name = match.name, isDrive = actual == ExpectedKind.DRIVE)
+        } else {
+            Verdict.Mismatch(actualKind = actual, name = match.name)
+        }
+    }
+}

--- a/src/main/kotlin/keepersecurity/util/KeeperRecordOutputValidators.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperRecordOutputValidators.kt
@@ -29,21 +29,21 @@ object KeeperRecordOutputValidators {
      */
     private val SYNC_BANNER_MARKERS = listOf(
         "Decrypted [",
-        "record(s)",
+        "synced record(s)",
         "breachwatch list",
-        "Use \"breachwatch list\" command"
+        "Use \"breachwatch list\" command",
     )
 
     /**
      * Error markers that the CLI prints for explicit failure cases (auth,
-     * validation, command typos, nsf-* warnings aborting the create). All
-     * matching is case-insensitive to absorb capitalisation differences
-     * between Commander releases.
+     * validation, command typos, nsf-* warnings aborting the create). Simple
+     * substring markers are case-insensitive; [INVALID_PHRASE_PATTERNS] use
+     * word boundaries so success lines like "skipped: 2 invalid fields" are
+     * not treated as failures.
      */
     private val ERROR_MARKERS = listOf(
         "error",
         "failed",
-        "invalid",
         "not found",
         // `nsf-record-add` aborts on attachment / unknown-field warnings unless
         // `-f` is supplied; the abort line begins with "Warning:" or "Aborted".
@@ -51,11 +51,17 @@ object KeeperRecordOutputValidators {
         "aborted",
         // Older Commander builds that pre-date Nested Shared Folders reject
         // the nsf-* namespace with one of these phrases.
-        // Retrying won't help, but the resulting error message will be
-        // much clearer than "validation failed after N attempts".
         "unknown command",
         "no such command",
-        "command not found"
+        "command not found",
+    )
+
+    private val INVALID_PHRASE_PATTERNS = listOf(
+        Regex("""invalid record\b""", RegexOption.IGNORE_CASE),
+        Regex("""invalid uid\b""", RegexOption.IGNORE_CASE),
+        Regex("""invalid field\b""", RegexOption.IGNORE_CASE),
+        Regex("""invalid command\b""", RegexOption.IGNORE_CASE),
+        Regex("""invalid folder\b""", RegexOption.IGNORE_CASE),
     )
 
     /**
@@ -107,7 +113,8 @@ object KeeperRecordOutputValidators {
 
     /** Returns true when the output contains any of the known error markers. */
     fun looksLikeError(output: String): Boolean =
-        ERROR_MARKERS.any { output.contains(it, ignoreCase = true) }
+        ERROR_MARKERS.any { output.contains(it, ignoreCase = true) } ||
+            INVALID_PHRASE_PATTERNS.any { it.containsMatchIn(output) }
 
     /**
      * Returns true when the output looks like an unrecoverable Commander

--- a/src/main/kotlin/keepersecurity/util/KeeperRecordOutputValidators.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperRecordOutputValidators.kt
@@ -1,0 +1,146 @@
+package keepersecurity.util
+
+/**
+ * Pure-function output validators for Keeper record-creation and record-update
+ * commands. Lives in `util/` so it can be unit-tested without spinning up
+ * IntelliJ test infrastructure and so the same matching logic runs for both
+ * the classic (`record-add` / `record-update`) and Nested Shared Folders
+ * (`nsf-record-add` / `nsf-record-update`) namespaces.
+ *
+ * The validators are *advisory* — they return `true` when the output looks
+ * like a real success result and `false` for transient sync banners,
+ * BreachWatch hints, CLI error strings, and `nsf-record-add`'s warning-aborted
+ * output. The caller (`KeeperCommandUtils.executeCommandWithRetry`) re-runs
+ * the command on `false` and ultimately throws after `maxRetries` attempts.
+ *
+ * These heuristics intentionally err on the side of *rejecting* questionable
+ * output: a false negative just costs a retry, while a false positive ends up
+ * inserting a `keeper://` reference to a record that may not actually exist.
+ */
+object KeeperRecordOutputValidators {
+
+    /** Length and shape of a Keeper record UID (Base64-URL-safe, 22 chars). */
+    private val UID_PATTERN = Regex("""[A-Za-z0-9_-]{22}""")
+
+    /**
+     * Sync banner / chatter that Commander emits while it's still settling its
+     * decryption cache after login. Hitting any of these strings means we
+     * should retry — the real command result is just about to follow.
+     */
+    private val SYNC_BANNER_MARKERS = listOf(
+        "Decrypted [",
+        "record(s)",
+        "breachwatch list",
+        "Use \"breachwatch list\" command"
+    )
+
+    /**
+     * Error markers that the CLI prints for explicit failure cases (auth,
+     * validation, command typos, nsf-* warnings aborting the create). All
+     * matching is case-insensitive to absorb capitalisation differences
+     * between Commander releases.
+     */
+    private val ERROR_MARKERS = listOf(
+        "error",
+        "failed",
+        "invalid",
+        "not found",
+        // `nsf-record-add` aborts on attachment / unknown-field warnings unless
+        // `-f` is supplied; the abort line begins with "Warning:" or "Aborted".
+        "warning:",
+        "aborted",
+        // Older Commander builds that pre-date Nested Shared Folders reject
+        // the nsf-* namespace with one of these phrases.
+        // Retrying won't help, but the resulting error message will be
+        // much clearer than "validation failed after N attempts".
+        "unknown command",
+        "no such command",
+        "command not found"
+    )
+
+    /**
+     * Subset of error markers that are *definitely* unrecoverable — retrying
+     * the same command will produce the same failure. Used by
+     * [isFatalError] so the retry loop can short-circuit instead of burning
+     * `maxRetries` attempts on a Commander state that won't change.
+     *
+     * "An unexpected error occurred" is Commander's catch-all wrapper for
+     * Python exceptions that escape a command handler. Once we see it, the
+     * underlying problem is on the user's CLI install (e.g. missing module,
+     * incompatible build) and no amount of retrying will fix it within the
+     * same Commander session.
+     */
+    private val FATAL_ERROR_MARKERS = listOf(
+        "an unexpected error occurred",
+        "no module named",
+        "modulenotfounderror",
+        "unknown command",
+        "no such command",
+        "command not found",
+        "not logged in",
+        "you are not logged in"
+    )
+
+    /**
+     * True when the [output] of a `record-add` / `nsf-record-add` call contains
+     * a freshly created record UID and is not a sync banner or error string.
+     */
+    fun isRecordAddSuccess(output: String): Boolean {
+        if (output.isBlank()) return false
+        val hasUid = UID_PATTERN.containsMatchIn(output)
+        return hasUid && !isSyncBanner(output) && !looksLikeError(output)
+    }
+
+    /**
+     * True when the [output] of a `record-update` / `nsf-record-update` call
+     * looks like a successful operation. Both classic and Nested Shared Folder
+     * Subfolders commands frequently return empty output on success, so the
+     * validator's job here is mostly to *reject* sync banners and error
+     * strings — empty output is accepted by default.
+     */
+    fun isRecordUpdateSuccess(output: String): Boolean =
+        !isSyncBanner(output) && !looksLikeError(output)
+
+    /** Returns true when the output is dominated by Commander's startup chatter. */
+    fun isSyncBanner(output: String): Boolean =
+        SYNC_BANNER_MARKERS.any { output.contains(it) }
+
+    /** Returns true when the output contains any of the known error markers. */
+    fun looksLikeError(output: String): Boolean =
+        ERROR_MARKERS.any { output.contains(it, ignoreCase = true) }
+
+    /**
+     * Returns true when the output looks like an unrecoverable Commander
+     * failure — typically a Python exception escaping a command handler, a
+     * missing module, or an unknown / disabled command. Used by the retry
+     * loop to bail early instead of repeating the same broken call.
+     */
+    fun isFatalError(output: String): Boolean =
+        FATAL_ERROR_MARKERS.any { output.contains(it, ignoreCase = true) }
+
+    /**
+     * Trim Commander output down to a single human-readable line suitable for
+     * surfacing in a `Messages.showErrorDialog`. Drops common prompt strings
+     * and the verbose "Type "debug" to toggle verbose error output" trailer.
+     */
+    fun summariseError(output: String): String {
+        val trimmed = output
+            .replace("My Vault>", "")
+            .replace("Keeper>", "")
+            .replace("Not logged in>", "")
+            .replace("Type \"debug\" to toggle verbose error output", "")
+            .replace("Type 'debug' to toggle verbose error output", "")
+            .lines()
+            .map { it.trim() }
+            .firstOrNull { it.isNotBlank() }
+            ?: output.trim()
+        return trimmed.take(300)
+    }
+
+    /**
+     * Extract the first Keeper record UID found in [output], or null when no
+     * 22-character UID-shaped token is present. Used by record-creation flows
+     * to surface the new UID in the editor reference.
+     */
+    fun extractRecordUid(output: String): String? = UID_PATTERN.find(output)?.value
+}

--- a/src/main/kotlin/keepersecurity/util/KeeperRecordValidator.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperRecordValidator.kt
@@ -1,0 +1,148 @@
+package keepersecurity.util
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import keepersecurity.model.KeeperRecord
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+/**
+ * Looks up a user-supplied record UID in the current vault to decide
+ * whether `record-update` (classic) or `nsf-record-update` (Nested Shared Folders)
+ * is the right CLI command. Replaces the *Update Keeper Record* Classic vs
+ * Nested Shared Folder prompt — the user only enters the UID, the
+ * plugin works out the rest.
+ *
+ * Uses the same `list --format json` payload that
+ * [keepersecurity.action.KeeperGetSecretAction] consumes when populating
+ * its picker: each row carries a `record_category` discriminator
+ * (`Classic` / `Nested`, plus older legacy wire values) that maps directly to the right
+ * command, and the payload is the only source of truth that
+ * empirically includes that field. We could try a single `get <uid>
+ * --format json` round-trip for speed, but the get-record JSON shape
+ * isn't guaranteed to include `record_category` on every Commander
+ * release, whereas `list --format json` does.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+object KeeperRecordValidator {
+
+    /** Which command we should dispatch to. */
+    enum class Kind { CLASSIC, DRIVE }
+
+    /** Outcome of [lookupRecord] / [lookupBlocking]. */
+    sealed class Verdict {
+        /** UID found; [kind] tells the caller which update command to use. */
+        data class Found(
+            val uuid: String,
+            val kind: Kind,
+            val title: String
+        ) : Verdict()
+
+        /** UID not present in the current vault listing. */
+        object NotFound : Verdict()
+
+        /**
+         * The CLI lookup itself failed (shell unhealthy, network down,
+         * etc.). Callers should usually surface the reason to the user
+         * rather than guess the namespace.
+         */
+        data class Unknown(val reason: String) : Verdict()
+    }
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        allowTrailingComma = true
+    }
+
+    private val logger: Logger = thisLogger()
+
+    /**
+     * Run the lookup under a small modal progress dialog so the EDT
+     * stays responsive while Commander walks the vault. Safe to call
+     * from the EDT.
+     *
+     * @param project Anchor project for the progress modal.
+     * @param uuid    The UID the user typed in the *Record UID* prompt.
+     */
+    fun lookupRecord(project: Project, uuid: String): Verdict {
+        val verdictHolder = arrayOf<Verdict>(Verdict.Unknown("not run"))
+        ProgressManager.getInstance().runProcessWithProgressSynchronously(
+            {
+                val indicator = ProgressManager.getInstance().progressIndicator
+                indicator?.text = "Refreshing Keeper vault\u2026"
+                verdictHolder[0] = lookupBlocking(uuid) { phase -> indicator?.text = phase }
+            },
+            "Looking up Keeper record\u2026",
+            false,
+            project
+        )
+        return verdictHolder[0]
+    }
+
+    /**
+     * Blocking variant. Intended for non-UI callers (e.g. unit tests or
+     * code already running on a background thread). The body must not
+     * be called from the EDT — it issues a synchronous `sync-down` +
+     * `list` against the persistent shell.
+     *
+     * The `sync-down` is required for the same reason the folder
+     * validator needs it (see [KeeperFolderValidator.verifyBlocking]):
+     * without it the persistent shell happily lists records that were
+     * deleted from another session, and we'd dispatch into a
+     * Commander-side phantom that reports local success but no vault
+     * change.
+     *
+     * @param onPhase optional progress hook; invoked with a short
+     *                human-readable status string before each phase
+     *                (sync, then list).
+     */
+    internal fun lookupBlocking(
+        uuid: String,
+        onPhase: (String) -> Unit = {}
+    ): Verdict {
+        if (uuid.isBlank()) return Verdict.NotFound
+
+        onPhase("Refreshing Keeper vault\u2026")
+        KeeperCommandUtils.syncDownBestEffort(logger)
+
+        onPhase("Looking up Keeper record\u2026")
+        val output = try {
+            KeeperCommandUtils.executeCommandWithRetry(
+                "list --format json",
+                KeeperCommandUtils.Presets.jsonArray(maxRetries = 2, timeoutSeconds = 60),
+                logger
+            )
+        } catch (ex: Exception) {
+            logger.warn("Could not fetch record list while looking up UID '$uuid': ${ex.message}")
+            return Verdict.Unknown(ex.message ?: ex.javaClass.simpleName)
+        }
+
+        val records = try {
+            val jsonText = KeeperJsonUtils.extractJsonArray(output, logger)
+            json.decodeFromString<List<KeeperRecord>>(jsonText)
+        } catch (ex: Exception) {
+            logger.warn("Could not parse record list while looking up UID '$uuid': ${ex.message}")
+            return Verdict.Unknown(ex.message ?: ex.javaClass.simpleName)
+        }
+
+        return classify(records, uuid)
+    }
+
+    /**
+     * Pure classifier extracted so the parsing-only branch can be
+     * tested without spinning up [KeeperShellService] / [ProgressManager].
+     */
+    internal fun classify(records: List<KeeperRecord>, uuid: String): Verdict {
+        val match = records.firstOrNull { it.recordUid == uuid } ?: return Verdict.NotFound
+        val kind = if (match.isKeeperDrive) Kind.DRIVE else Kind.CLASSIC
+        return Verdict.Found(
+            uuid = uuid,
+            kind = kind,
+            title = match.title.ifBlank { uuid }
+        )
+    }
+}

--- a/src/main/kotlin/keepersecurity/util/KeeperRecordValidator.kt
+++ b/src/main/kotlin/keepersecurity/util/KeeperRecordValidator.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import keepersecurity.model.KeeperRecord
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 /**
@@ -42,7 +41,7 @@ object KeeperRecordValidator {
         ) : Verdict()
 
         /** UID not present in the current vault listing. */
-        object NotFound : Verdict()
+        data object NotFound : Verdict()
 
         /**
          * The CLI lookup itself failed (shell unhealthy, network down,

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,14 +59,14 @@
         <action id="keepersecurity.action.KeeperFolderSelectAction"
                 class="keepersecurity.action.KeeperFolderSelectAction"
                 text="Get Keeper Folder"
-                description="Get folder UUID from Keeper Vault">
+                description="Select any vault folder (Classic or Nested Shared Folder) and save it for record creation">
                 <add-to-group group-id="KeeperVaultGroup" anchor="last"/>
         </action>
 
         <action id="keepersecurity.action.KeeperGetSecretAction"
                 class="keepersecurity.action.KeeperGetSecretAction"
                 text="Get Keeper Secret"
-                description="Choose a Keeper record and field; inserts keeper:// in .env/scripts or {{$keeper(...)}} in .http files">
+                description="Choose any Keeper record (Classic or Nested Shared Folder) and field; inserts keeper:// in .env/scripts or {{$keeper(...)}} in .http files">
                 <add-to-group group-id="KeeperVaultGroup" anchor="last"/>
         </action>
 
@@ -105,12 +105,12 @@
             <action id="keepersecurity.action.KeeperFolderSelectActionEditor"
                     class="keepersecurity.action.KeeperFolderSelectAction"
                     text="Get Keeper Folder"
-                    description="Select a Keeper folder and save its UUID"/>
+                    description="Select any vault folder (Classic or Nested Shared Folder) and save it"/>
 
             <action id="keepersecurity.action.KeeperGetSecretActionEditor"
                 class="keepersecurity.action.KeeperGetSecretAction"
                 text="Get Keeper Secret"
-                description="Choose a Keeper record and field; inserts keeper:// or HTTP Client {{$keeper(...)}}"/>
+                description="Choose any Keeper record (Classic or Nested Shared Folder) and field; inserts keeper:// or HTTP Client {{$keeper(...)}}"/>
 
             <!-- Generate Keeper Secrets action (Editor popup) -->
             <action id="keepersecurity.action.KeeperGenerateSecretsActionEditor"

--- a/src/main/resources/messages/KeeperSecurity.properties
+++ b/src/main/resources/messages/KeeperSecurity.properties
@@ -7,7 +7,7 @@ action.auth.name=Check Keeper Authorization
 action.auth.description=Verify Keeper CLI installation and authentication status
 
 action.getSecret.name=Get Keeper Secret
-action.getSecret.description=Insert existing secrets from vault as references
+action.getSecret.description=Insert existing secrets (Classic or Nested Shared Folder) from the vault as references
 
 action.addRecord.name=Add Keeper Record
 action.addRecord.description=Create new vault record from selected text and replace with reference
@@ -19,7 +19,7 @@ action.generateSecret.name=Generate Keeper Secret
 action.generateSecret.description=Generate secure password and create new vault record
 
 action.selectFolder.name=Get Keeper Folder
-action.selectFolder.description=Select vault folder for organized secret storage
+action.selectFolder.description=Select any vault folder (Classic or Nested Shared Folder) and save it for record creation
 
 action.runSecurely.name=Run Keeper Securely
 action.runSecurely.description=Execute commands with secrets injected from .env file

--- a/src/test/kotlin/keepersecurity/action/KeeperActionTestSuite.kt
+++ b/src/test/kotlin/keepersecurity/action/KeeperActionTestSuite.kt
@@ -138,4 +138,54 @@ class KeeperActionTestSuite : BaseKeeperActionTest() {
             }
         }
     }
+
+    @Test
+    fun `test KeeperFolderSelectAction handles mixed-source folders without throwing`() {
+        // Unified picker should accept both Classic and Drive folders in
+        // the same listing — Commander's `ls --format=json -f -R` returns
+        // them together once Nested Shared Folders is enabled on the account.
+        MockKeeperService.addMockCommand(
+            "ls --format=json -f -R",
+            """
+            [
+                {"uid": "legacy-folder-uid", "name": "Legacy Folder", "source": "Legacy"},
+                {"uid": "drive-folder-uid",  "name": "Drive Folder",  "source": "KeeperDrive"}
+            ]
+            """.trimIndent()
+        )
+
+        val action = KeeperFolderSelectAction()
+        val event = createActionEventWithProjectOnly()
+
+        try {
+            action.actionPerformed(event)
+            assertTrue("Action should complete without throwing", true)
+        } catch (e: Exception) {
+            fail("Action should not throw exception: ${e.message}")
+        }
+    }
+
+    @Test
+    fun `test KeeperGetSecretAction handles mixed-source records without throwing`() {
+        MockKeeperService.addMockCommand(
+            "list --format json",
+            """
+            [
+                {"record_uid": "legacy-record-uid-1", "title": "Classic", "record_category": "Classic"},
+                {"record_uid": "drive-record-uid-12", "title": "Drive",   "record_category": "KeeperDrive"}
+            ]
+            """.trimIndent()
+        )
+
+        val action = KeeperGetSecretAction()
+        configureFileWithCaretAt("api_key = ", 9)
+        val event = createActionEventWithEditor()
+
+        try {
+            action.actionPerformed(event)
+            assertTrue("Action should complete without throwing", true)
+        } catch (e: Exception) {
+            fail("Action should not throw exception: ${e.message}")
+        }
+    }
 }

--- a/src/test/kotlin/keepersecurity/action/KeeperActionsBasicTest.kt
+++ b/src/test/kotlin/keepersecurity/action/KeeperActionsBasicTest.kt
@@ -22,19 +22,19 @@ class KeeperActionsBasicTest {
         System.clearProperty("java.awt.headless")
     }
 
+    private fun allActions() = listOf(
+        KeeperRecordAddAction(),
+        KeeperGenerateSecretsAction(),
+        KeeperFolderSelectAction(),
+        KeeperGetSecretAction(),
+        KeeperRecordUpdateAction(),
+        KeeperSecretAction(),
+        KeeperAuthAction()
+    )
+
     @Test
     fun `test all actions can be instantiated`() {
-        val actions = listOf(
-            KeeperRecordAddAction(),
-            KeeperGenerateSecretsAction(),
-            KeeperFolderSelectAction(),
-            KeeperGetSecretAction(),
-            KeeperRecordUpdateAction(),
-            KeeperSecretAction(),
-            KeeperAuthAction()
-        )
-        
-        actions.forEach { action ->
+        allActions().forEach { action ->
             assertNotNull("Action should not be null", action)
             assertNotNull("Action text should not be null", action.templatePresentation.text)
             assertTrue("Action text should not be empty", action.templatePresentation.text.isNotEmpty())
@@ -52,7 +52,7 @@ class KeeperActionsBasicTest {
             KeeperSecretAction() to "Run Keeper Securely",
             KeeperAuthAction() to "Check Keeper Authorization"
         )
-        
+
         expectedNames.forEach { (action, expectedText) ->
             assertEquals("Action text should match", expectedText, action.templatePresentation.text)
         }
@@ -60,18 +60,11 @@ class KeeperActionsBasicTest {
 
     @Test
     fun `test actions extend AnAction`() {
-        val actions = listOf(
-            KeeperRecordAddAction(),
-            KeeperGenerateSecretsAction(),
-            KeeperFolderSelectAction(),
-            KeeperGetSecretAction(),
-            KeeperRecordUpdateAction(),
-            KeeperSecretAction(),
-            KeeperAuthAction()
-        )
-        
-        actions.forEach { action ->
-            assertTrue("Action should extend AnAction", action is com.intellij.openapi.actionSystem.AnAction)
+        allActions().forEach { action ->
+            assertTrue(
+                "Action should extend AnAction",
+                action is com.intellij.openapi.actionSystem.AnAction
+            )
         }
     }
 }

--- a/src/test/kotlin/keepersecurity/action/KeeperActionsIntegrationTest.kt
+++ b/src/test/kotlin/keepersecurity/action/KeeperActionsIntegrationTest.kt
@@ -10,17 +10,19 @@ import org.junit.Before
 @TestDataPath("\$CONTENT_ROOT/src/test/testData")
 class KeeperActionsIntegrationTest : BasePlatformTestCase() {
 
+    private fun allActions(): List<AnAction> = listOf(
+        KeeperRecordAddAction(),
+        KeeperGenerateSecretsAction(),
+        KeeperFolderSelectAction(),
+        KeeperGetSecretAction(),
+        KeeperRecordUpdateAction(),
+        KeeperSecretAction()
+    )
+
     @Test
     fun `test all keeper actions can be instantiated`() {
-        val actions = listOf(
-            KeeperRecordAddAction(),
-            KeeperGenerateSecretsAction(),
-            KeeperFolderSelectAction(),
-            KeeperGetSecretAction(),
-            KeeperRecordUpdateAction(),
-            KeeperSecretAction()
-        )
-        
+        val actions = allActions()
+
         actions.forEach { action ->
             assertNotNull("Action should not be null", action)
             assertNotNull("Action text should not be null", action.templatePresentation.text)
@@ -39,7 +41,7 @@ class KeeperActionsIntegrationTest : BasePlatformTestCase() {
             "Update Keeper Record" to KeeperRecordUpdateAction(),
             "Run Keeper Securely" to KeeperSecretAction()
         )
-        
+
         actions.forEach { (expectedText, action) ->
             assertEquals("Action text should match", expectedText, action.templatePresentation.text)
         }
@@ -47,35 +49,15 @@ class KeeperActionsIntegrationTest : BasePlatformTestCase() {
 
     @Test
     fun `test actions handle basic lifecycle correctly`() {
-        val actions = listOf(
-            KeeperRecordAddAction(),
-            KeeperGenerateSecretsAction(),
-            KeeperFolderSelectAction(),
-            KeeperGetSecretAction(),
-            KeeperRecordUpdateAction(),
-            KeeperSecretAction()
-        )
-        
-        actions.forEach { action ->
-            // Test that each action can be created and has basic properties
+        allActions().forEach { action ->
             assertNotNull("Action template should exist", action.templatePresentation)
-            // Note: isInternalAction doesn't exist, so we'll test something else
             assertTrue("Action should be enabled by default", action.templatePresentation.isEnabled)
         }
     }
 
     @Test
     fun `test actions have consistent naming convention`() {
-        val actions = listOf(
-            KeeperRecordAddAction(),
-            KeeperGenerateSecretsAction(),
-            KeeperFolderSelectAction(),
-            KeeperGetSecretAction(),
-            KeeperRecordUpdateAction(),
-            KeeperSecretAction()
-        )
-        
-        actions.forEach { action ->
+        allActions().forEach { action ->
             val actionName = action.javaClass.simpleName
             assertTrue("Action name should start with Keeper", actionName.startsWith("Keeper"))
             assertTrue("Action name should end with Action", actionName.endsWith("Action"))
@@ -84,20 +66,31 @@ class KeeperActionsIntegrationTest : BasePlatformTestCase() {
 
     @Test
     fun `test actions have descriptions`() {
-        val actions = listOf(
-            KeeperRecordAddAction(),
-            KeeperGenerateSecretsAction(),
-            KeeperFolderSelectAction(),
-            KeeperGetSecretAction(),
-            KeeperRecordUpdateAction(),
-            KeeperSecretAction()
-        )
-        
-        actions.forEach { action ->
+        allActions().forEach { action ->
             val text = action.templatePresentation.text
             assertNotNull("Action should have presentation text", text)
             assertTrue("Action text should contain 'Keeper'", text.contains("Keeper"))
         }
+    }
+
+    @Test
+    fun `test unified folder and secret pickers are present`() {
+        // Drive lookups are folded into the classic pickers — Commander's
+        // unified `list` / `ls --format=json` already returns Drive rows
+        // alongside Classic ones, so a single menu item suffices. If
+        // separate Drive-only actions are reintroduced later, update this
+        // canary to assert both surfaces.
+        val classes = allActions().map { it.javaClass.simpleName }
+        assertTrue(classes.contains("KeeperFolderSelectAction"))
+        assertTrue(classes.contains("KeeperGetSecretAction"))
+        assertFalse(
+            "Drive-specific folder picker should be folded into KeeperFolderSelectAction",
+            classes.contains("KeeperDriveFolderSelectAction")
+        )
+        assertFalse(
+            "Drive-specific secret picker should be folded into KeeperGetSecretAction",
+            classes.contains("KeeperGetDriveSecretAction")
+        )
     }
 
     override fun getTestDataPath() = "src/test/testData"

--- a/src/test/kotlin/keepersecurity/action/KeeperGenerateSecretsActionTest.kt
+++ b/src/test/kotlin/keepersecurity/action/KeeperGenerateSecretsActionTest.kt
@@ -55,4 +55,29 @@ class KeeperGenerateSecretsActionTest {
             action1.templatePresentation.text, 
             action2.templatePresentation.text)
     }
+
+    @Test
+    fun `test action exposes Classic and Drive GenerateTarget branches`() {
+        val classicTarget = Class.forName(
+            "keepersecurity.action.KeeperGenerateSecretsAction\$GenerateTarget\$Classic"
+        )
+        val driveTarget = Class.forName(
+            "keepersecurity.action.KeeperGenerateSecretsAction\$GenerateTarget\$Drive"
+        )
+        assertNotNull("Classic GenerateTarget branch should exist", classicTarget)
+        assertNotNull("Drive GenerateTarget branch should exist", driveTarget)
+    }
+
+    @Test
+    fun `test action declares Drive and Classic record-add command builders`() {
+        val methods = KeeperGenerateSecretsAction::class.java.declaredMethods.map { it.name }
+        assertTrue(
+            "Classic command builder should be declared",
+            methods.any { it == "buildClassicAddCommand" }
+        )
+        assertTrue(
+            "Drive command builder should be declared",
+            methods.any { it == "buildDriveAddCommand" }
+        )
+    }
 }

--- a/src/test/kotlin/keepersecurity/action/KeeperRecordAddActionTest.kt
+++ b/src/test/kotlin/keepersecurity/action/KeeperRecordAddActionTest.kt
@@ -81,4 +81,40 @@ class KeeperRecordAddActionTest {
         
         assertEquals("Both instances should have same standard fields", fields1, fields2)
     }
+
+    @Test
+    fun `test action exposes Classic and Drive AddTarget branches`() {
+        // The AddTarget sealed class is the dispatch surface between the
+        // classic `record-add` and `nsf-record-add` branches inside the
+        // action. Loading both nested classes by name ensures a future
+        // refactor doesn't silently delete a branch.
+        val classicTarget = Class.forName(
+            "keepersecurity.action.KeeperRecordAddAction\$AddTarget\$Classic"
+        )
+        val driveTarget = Class.forName(
+            "keepersecurity.action.KeeperRecordAddAction\$AddTarget\$Drive"
+        )
+        assertNotNull("Classic AddTarget branch should exist", classicTarget)
+        assertNotNull("Drive AddTarget branch should exist", driveTarget)
+    }
+
+    @Test
+    fun `test action declares Drive command builder`() {
+        val method = KeeperRecordAddAction::class.java.declaredMethods
+            .firstOrNull { it.name == "buildDriveAddCommand" }
+        assertNotNull(
+            "Drive command builder should be declared on the action",
+            method
+        )
+    }
+
+    @Test
+    fun `test action declares Classic command builder for the classic branch`() {
+        val method = KeeperRecordAddAction::class.java.declaredMethods
+            .firstOrNull { it.name == "buildClassicAddCommand" }
+        assertNotNull(
+            "Classic command builder should still be present after the Drive refactor",
+            method
+        )
+    }
 }

--- a/src/test/kotlin/keepersecurity/action/KeeperRecordTargetPromptTest.kt
+++ b/src/test/kotlin/keepersecurity/action/KeeperRecordTargetPromptTest.kt
@@ -1,0 +1,93 @@
+package keepersecurity.action
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [KeeperRecordTargetPrompt]. The dialog itself can't be driven
+ * from a unit test (it needs the EDT plus a real `Messages.showDialog`
+ * callback), and a `BasePlatformTestCase` fixture trips a coroutines /
+ * test-framework mismatch in the current IntelliJ Platform version — so
+ * this test focuses on the prompt's *static* contract:
+ *
+ *  - preference key names are stable across releases,
+ *  - the `AddOutcome` sealed hierarchy stays exhaustive (this is the
+ *    contract every Add / Generate caller switches on).
+ *
+ * The Update prompt was retired in favour of
+ * [keepersecurity.util.KeeperRecordValidator] (record UID lookup against
+ * `list --format json`), so the old `Target` enum / `UpdateOutcome` /
+ * `PREF_LAST_TARGET` surface is gone. Per-project persistence is
+ * verified indirectly via the action-level smoke tests in
+ * `KeeperActionTestSuite`.
+ */
+class KeeperRecordTargetPromptTest {
+
+    @Before
+    fun setUp() {
+        System.setProperty("keeper.test.mode", "true")
+        System.setProperty("java.awt.headless", "true")
+    }
+
+    @After
+    fun tearDown() {
+        System.clearProperty("keeper.test.mode")
+        System.clearProperty("java.awt.headless")
+    }
+
+    @Test
+    fun `test preference keys are stable across releases`() {
+        // These keys are persisted in user workspaces — renaming them would
+        // silently invalidate every selection the user has already made.
+        assertEquals("keeper.drive.folder.uuid", KeeperRecordTargetPrompt.PREF_DRIVE_FOLDER_UUID)
+        assertEquals("keeper.drive.folder.name", KeeperRecordTargetPrompt.PREF_DRIVE_FOLDER_NAME)
+        assertEquals("keeper.folder.uuid", KeeperRecordTargetPrompt.PREF_CLASSIC_FOLDER_UUID)
+        assertEquals("keeper.folder.name", KeeperRecordTargetPrompt.PREF_CLASSIC_FOLDER_NAME)
+    }
+
+    @Test
+    fun `test AddOutcome sealed shape supports Cancelled, Classic and Drive`() {
+        // Compile-time exhaustiveness check: if a new branch is added, this
+        // `when` will start failing to compile and force the test to be
+        // updated, which is exactly the canary we want.
+        val outcomes = listOf(
+            KeeperRecordTargetPrompt.AddOutcome.Cancelled,
+            KeeperRecordTargetPrompt.AddOutcome.Classic(folderUuid = "uuid", folderName = "name"),
+            KeeperRecordTargetPrompt.AddOutcome.Drive(folderUuid = "uuid", folderName = "name")
+        )
+        outcomes.forEach { outcome ->
+            val label = when (outcome) {
+                is KeeperRecordTargetPrompt.AddOutcome.Cancelled -> "cancelled"
+                is KeeperRecordTargetPrompt.AddOutcome.Classic -> "classic"
+                is KeeperRecordTargetPrompt.AddOutcome.Drive -> "drive"
+            }
+            assertNotNull(label)
+        }
+    }
+
+    @Test
+    fun `test Classic AddOutcome carries optional folder UUID and name`() {
+        val withFolder = KeeperRecordTargetPrompt.AddOutcome.Classic("uuid-1", "Classic Folder")
+        val classicRoot = KeeperRecordTargetPrompt.AddOutcome.Classic(folderUuid = null, folderName = null)
+
+        assertEquals("uuid-1", withFolder.folderUuid)
+        assertEquals("Classic Folder", withFolder.folderName)
+        assertNull(classicRoot.folderUuid)
+        assertNull(classicRoot.folderName)
+    }
+
+    @Test
+    fun `test Drive AddOutcome carries optional folder UUID and name`() {
+        val withFolder = KeeperRecordTargetPrompt.AddOutcome.Drive("uuid-1", "Drive Folder")
+        val driveRoot = KeeperRecordTargetPrompt.AddOutcome.Drive(folderUuid = null, folderName = null)
+
+        assertEquals("uuid-1", withFolder.folderUuid)
+        assertEquals("Drive Folder", withFolder.folderName)
+        assertNull(driveRoot.folderUuid)
+        assertNull(driveRoot.folderName)
+    }
+}

--- a/src/test/kotlin/keepersecurity/action/KeeperRecordUpdateActionTest.kt
+++ b/src/test/kotlin/keepersecurity/action/KeeperRecordUpdateActionTest.kt
@@ -80,6 +80,21 @@ class KeeperRecordUpdateActionTest {
         }
     }
 
+    @Test
+    fun `test action references the shared output validator helper`() {
+        // Inline validators were extracted into KeeperRecordOutputValidators
+        // so the same matching logic can run for both classic `record-update`
+        // and `nsf-record-update`. This is a class-level smoke check; the
+        // detailed behaviour lives in KeeperRecordOutputValidatorsTest.
+        val helperFqn = "keepersecurity.util.KeeperRecordOutputValidators"
+        try {
+            val cls = Class.forName(helperFqn)
+            assertNotNull("Helper should be loadable", cls)
+        } catch (ex: ClassNotFoundException) {
+            fail("Expected $helperFqn to be on the classpath: ${ex.message}")
+        }
+    }
+
     private fun getPrivateField(obj: Any, fieldName: String): Any? {
         val field = obj.javaClass.getDeclaredField(fieldName)
         field.isAccessible = true

--- a/src/test/kotlin/keepersecurity/model/KeeperModelsTest.kt
+++ b/src/test/kotlin/keepersecurity/model/KeeperModelsTest.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.SerializationException
 import org.junit.Test
 import org.junit.Assert.*

--- a/src/test/kotlin/keepersecurity/model/KeeperModelsTest.kt
+++ b/src/test/kotlin/keepersecurity/model/KeeperModelsTest.kt
@@ -319,6 +319,157 @@ class KeeperModelsTest {
     }
 
     @Test
+    fun `KeeperFolder isKeeperDrive returns true for nested_share_folder source`() {
+        val folder = KeeperFolder(
+            folderUid = "drive-folder-123",
+            name = "Keeper Drive Test folder",
+            source = KeeperFolder.SOURCE_NESTED_SHARE_FOLDER
+        )
+        assertTrue(folder.isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperFolder isKeeperDrive returns false for classic_folder source`() {
+        val folder = KeeperFolder(
+            folderUid = "classic-folder-123",
+            name = "kcm-creds",
+            source = KeeperFolder.SOURCE_CLASSIC_FOLDER
+        )
+        assertFalse(folder.isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperFolder parses newer classic_folder and nested_share_folder list`() {
+        val raw = """
+        [
+            {
+                "type": "folder",
+                "uid": "y2cG8GbSF3k_TT0D-EOH1w",
+                "name": "kcm-creds",
+                "source": "classic_folder"
+            },
+            {
+                "type": "folder",
+                "uid": "2zHC3Umb41PnVECFZxYTXw",
+                "name": "Keeper Drive Test folder",
+                "source": "nested_share_folder"
+            }
+        ]
+        """
+        val folders = json.decodeFromString<List<KeeperFolder>>(raw)
+        assertEquals(2, folders.size)
+        assertFalse(folders[0].isKeeperDrive)
+        assertTrue(folders[1].isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperFolder isKeeperDrive returns true for KeeperDrive source`() {
+        val folder = KeeperFolder(
+            folderUid = "drive-folder-123",
+            name = "Drive Folder",
+            source = KeeperFolder.SOURCE_KEEPER_DRIVE
+        )
+        assertTrue(folder.isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperFolder isKeeperDrive returns false for Legacy source`() {
+        val folder = KeeperFolder(
+            folderUid = "legacy-folder-123",
+            name = "Legacy Folder",
+            source = KeeperFolder.SOURCE_LEGACY
+        )
+        assertFalse(folder.isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperFolder isKeeperDrive returns false when source is missing`() {
+        val folder = KeeperFolder(folderUid = "old-folder", name = "Old Folder")
+        assertFalse(folder.isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperFolder isKeeperDrive is case-insensitive`() {
+        val folder = KeeperFolder(
+            folderUid = "drive-folder-123",
+            name = "Drive Folder",
+            source = "keeperdrive"
+        )
+        assertTrue(folder.isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperFolder parses mixed Legacy and KeeperDrive list`() {
+        val raw = """
+        [
+            {
+                "uid": "legacy-folder-uid-1234",
+                "name": "Legacy Folder",
+                "source": "Legacy"
+            },
+            {
+                "uid": "drive-folder-uid-1234",
+                "name": "Drive Folder",
+                "source": "KeeperDrive"
+            }
+        ]
+        """
+        val folders = json.decodeFromString<List<KeeperFolder>>(raw)
+        assertEquals(2, folders.size)
+        assertFalse(folders[0].isKeeperDrive)
+        assertTrue(folders[1].isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperRecord isKeeperDrive returns true for Nested record_category`() {
+        val record = KeeperRecord(
+            recordUid = "FnxkikNsz2W7OyqDB9fTAg",
+            title = "iTerm2NSFRec",
+            recordCategory = KeeperRecord.CATEGORY_NESTED
+        )
+        assertTrue(record.isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperRecord isKeeperDrive returns true for KeeperDrive record_category`() {
+        val record = KeeperRecord(
+            recordUid = "drive-record-uid-12345",
+            title = "Drive Record",
+            recordCategory = KeeperRecord.CATEGORY_KEEPER_DRIVE
+        )
+        assertTrue(record.isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperRecord isKeeperDrive returns false for Classic or missing record_category`() {
+        val classic = KeeperRecord(
+            recordUid = "classic-record-uid-123",
+            title = "Classic Record",
+            recordCategory = KeeperRecord.CATEGORY_CLASSIC
+        )
+        val noCategory = KeeperRecord(recordUid = "old-record-uid-12345", title = "Old Record")
+        assertFalse(classic.isKeeperDrive)
+        assertFalse(noCategory.isKeeperDrive)
+    }
+
+    @Test
+    fun `KeeperRecord parses real list --format json output with record_category`() {
+        // Field name + values straight from `list --format json` (Commander
+        // emits `record_category` with "Classic" / "KeeperDrive" — note this
+        // differs from the folder side's `source` / "Legacy").
+        val raw = """
+        [
+            {"record_uid": "classic-rec-uid-1234", "title": "Classic Rec", "record_category": "Classic"},
+            {"record_uid": "drive-rec-uid-123456",  "title": "Drive Rec",   "record_category": "KeeperDrive"}
+        ]
+        """
+        val records = json.decodeFromString<List<KeeperRecord>>(raw)
+        assertEquals(2, records.size)
+        assertFalse(records[0].isKeeperDrive)
+        assertTrue(records[1].isKeeperDrive)
+    }
+
+    @Test
     fun `test GeneratedPassword from real generate command`() {
         val generateOutput = """
         [

--- a/src/test/kotlin/keepersecurity/service/MockKeeperService.kt
+++ b/src/test/kotlin/keepersecurity/service/MockKeeperService.kt
@@ -1,60 +1,107 @@
 package keepersecurity.service
 
 /**
- * Mock Keeper service that completely bypasses biometric authentication for tests
+ * Mock Keeper service that completely bypasses biometric authentication for
+ * tests and provides deterministic responses for both Classic vault and
+ * Nested Shared Folders commands.
+ *
+ * The fixtures returned by the mock mirror the unified shapes the real CLI
+ * produces:
+ *
+ *  - `ls --format=json -f -R` returns a mixed list of Classic and
+ *    Nested Shared Folders, each tagged with a `source` discriminator
+ *    (`classic_folder` / `nested_share_folder`, plus older legacy wire values).
+ *  - `list --format json` returns a similarly mixed list of records, each
+ *    tagged with a `record_category` discriminator (`Classic` / `Nested`,
+ *    plus older legacy wire values).
+ *  - `get <uid> --format json` accepts both Classic and Nested Shared Folder
+ *    UIDs (the real CLI does the same), so no separate `nsf-get` mock is
+ *    required for the read path.
+ *  - Only the mutating Nested Shared Folder commands (`nsf-record-add` /
+ *    `nsf-record-update`) are routed separately because Commander keeps
+ *    them as distinct command names.
  */
 object MockKeeperService {
     private var isReady = true // Always ready in tests
     private val mockCommands = mutableMapOf<String, String>()
     private var shouldFailNextCommand = false
-    
+
+    /** Sample UID used across fixtures so tests can match on a stable value. */
+    const val MOCK_CLASSIC_RECORD_UID = "test123456789012345678"
+    const val MOCK_DRIVE_RECORD_UID = "drv7890123456789012345"
+    const val MOCK_CLASSIC_FOLDER_UID = "folder123456789012345"
+    const val MOCK_DRIVE_FOLDER_UID = "drvfolder12345678901a"
+
     init {
         // Setup default successful responses to avoid any authentication
         setupDefaultSuccessfulResponses()
     }
-    
+
     private fun setupDefaultSuccessfulResponses() {
-        // Common successful responses that bypass all authentication
-        addMockCommand("list --format json", 
-            """[{"record_uid": "test123456789012345678", "title": "Test Login Record"}]""")
-        
-        addMockCommand("ls --format=json -f -R",
-            """[{"folder_uid": "folder123456789012345", "name": "Test Folder"}]""")
-        
+        // Mixed Classic + Nested Shared record listing matches the
+        // production payload shape (each entry is tagged via
+        // `record_category` for namespace filtering).
+        addMockCommand(
+            "list --format json",
+            """
+            [
+                {"record_uid": "$MOCK_CLASSIC_RECORD_UID", "title": "Classic Login", "record_category": "Classic"},
+                {"record_uid": "$MOCK_DRIVE_RECORD_UID", "title": "Drive Login", "record_category": "KeeperDrive"}
+            ]
+            """.trimIndent()
+        )
+
+        // Mixed Classic + Nested Shared Folder listing — same `source`
+        // discriminator
+        addMockCommand(
+            "ls --format=json -f -R",
+            """
+            [
+                {"uid": "$MOCK_CLASSIC_FOLDER_UID", "name": "Classic Folder", "source": "Legacy"},
+                {"uid": "$MOCK_DRIVE_FOLDER_UID", "name": "Drive Folder", "source": "KeeperDrive"}
+            ]
+            """.trimIndent()
+        )
+
         addMockCommand("generate -f json",
             """[{"password": "MockGeneratedPassword123"}]""")
-        
+
         addMockCommand("", "My Vault>") // Empty command response
         addMockCommand("this-device", "Device Name: Test Device\nStatus: SUCCESSFUL")
-        
-        // Pattern-based responses for dynamic commands
-        addMockCommandPattern(Regex("get .* --format json.*"), 
-            """{"record_uid": "test123", "password": "mock-password", "login": "mock-user"}""")
-        
-        addMockCommandPattern(Regex("record-add.*"), "test123456789012345678")
+
+        // Pattern-based responses for dynamic commands. Both classic and
+        // Nested Shared Folders namespaces are covered. `get <UID> --format json`
+        // works on Nested Shared Folder UIDs in the real CLI, so the same fixture
+        // handles both.
+        addMockCommandPattern(Regex("get .* --format json.*"),
+            """{"record_uid": "$MOCK_CLASSIC_RECORD_UID", "password": "mock-password", "login": "mock-user"}""")
+
+        addMockCommandPattern(Regex("nsf-record-add.*"), MOCK_DRIVE_RECORD_UID)
+        addMockCommandPattern(Regex("nsf-record-update.*"), "")
+        addMockCommandPattern(Regex("record-add.*"), MOCK_CLASSIC_RECORD_UID)
         addMockCommandPattern(Regex("record-update.*"), "")
     }
-    
+
     fun setReady(ready: Boolean) {
         isReady = ready
     }
-    
+
     fun addMockCommand(command: String, response: String) {
         mockCommands[command] = response
     }
-    
+
     fun addMockCommandPattern(pattern: Regex, response: String) {
         mockCommands[pattern.pattern] = response
     }
-    
+
     fun clearMockCommands() {
         mockCommands.clear()
     }
-    
+
     fun setNextCommandToFail(fail: Boolean) {
         shouldFailNextCommand = fail
     }
-    
+
     fun executeCommand(command: String): String {
         if (shouldFailNextCommand) {
             shouldFailNextCommand = false
@@ -68,20 +115,32 @@ object MockKeeperService {
         // Try exact match first
         mockCommands[command]?.let { return it }
         
-        // Try pattern matching
-        mockCommands.entries.forEach { (pattern, response) ->
-            if (command.contains(pattern) || command.matches(Regex(pattern))) {
-                return response
+        // Try pattern matching. `nsf-record-add` is registered before
+        // `record-add`, so the more specific nsf-* patterns win when the
+        // command string contains both substrings.
+        mockCommands.entries
+            .sortedByDescending { it.key.length }
+            .forEach { (pattern, response) ->
+                if (command.contains(pattern) || command.matches(Regex(pattern))) {
+                    return response
+                }
             }
-        }
-        
-        // Always return successful responses - HARDCODE SUCCESS!
+
+        // Always return successful responses. The unified `list` / `ls`
+        // commands already return both Classic and Nested Shared Folder rows
+        // (records carry `record_category`, folders carry `source`), so
+        // there are no Drive-specific list / get fallthrough branches.
+        // Only the mutating `nsf-record-add` / `nsf-record-update` paths
+        // are still routed by prefix because Commander still exposes them
+        // as distinct commands.
         return when {
             command.startsWith("generate") -> """[{"password": "HardcodedTestPassword123"}]"""
-            command.startsWith("list") -> """[{"record_uid": "hardcoded123456789012", "title": "Hardcoded Test Record"}]"""
+            command.startsWith("nsf-record-add") -> MOCK_DRIVE_RECORD_UID
+            command.startsWith("nsf-record-update") -> ""
+            command.startsWith("list") -> """[{"record_uid": "$MOCK_CLASSIC_RECORD_UID", "title": "Hardcoded Test Record", "record_category": "Classic"}]"""
             command.startsWith("get") -> """{"password": "hardcoded-secret", "login": "test-user", "title": "Test Record"}"""
-            command.startsWith("ls") -> """[{"folder_uid": "hardcoded123456789012", "name": "Test Folder"}]"""
-            command.startsWith("record-add") -> "hardcoded123456789012345"
+            command.startsWith("ls") -> """[{"uid": "$MOCK_CLASSIC_FOLDER_UID", "name": "Test Folder", "source": "Legacy"}]"""
+            command.startsWith("record-add") -> MOCK_CLASSIC_RECORD_UID
             command.startsWith("record-update") -> ""
             else -> "hardcoded-success"
         }

--- a/src/test/kotlin/keepersecurity/ui/KeeperListPickerItemTest.kt
+++ b/src/test/kotlin/keepersecurity/ui/KeeperListPickerItemTest.kt
@@ -1,6 +1,8 @@
 package keepersecurity.ui
 
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -23,5 +25,13 @@ class KeeperListPickerItemTest {
     fun `matchesSearch accepts empty query`() {
         val item = KeeperListPickerItem("Anything", KeeperVaultBadge.NESTED)
         assertTrue(item.matchesSearch(""))
+    }
+
+    @Test
+    fun `duplicate labels with different ids are distinct picker rows`() {
+        val classicA = KeeperListPickerItem("Shared", KeeperVaultBadge.CLASSIC, id = "uid-classic-a")
+        val classicB = KeeperListPickerItem("Shared", KeeperVaultBadge.CLASSIC, id = "uid-classic-b")
+        assertNotEquals(classicA, classicB)
+        assertEquals("uid-classic-b", classicB.id)
     }
 }

--- a/src/test/kotlin/keepersecurity/ui/KeeperListPickerItemTest.kt
+++ b/src/test/kotlin/keepersecurity/ui/KeeperListPickerItemTest.kt
@@ -1,0 +1,27 @@
+package keepersecurity.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeeperListPickerItemTest {
+
+    @Test
+    fun `matchesSearch finds label substring`() {
+        val item = KeeperListPickerItem("Production API Key", KeeperVaultBadge.NESTED)
+        assertTrue(item.matchesSearch("production"))
+    }
+
+    @Test
+    fun `matchesSearch finds badge text`() {
+        val item = KeeperListPickerItem("Shared Login", KeeperVaultBadge.CLASSIC)
+        assertTrue(item.matchesSearch("classic"))
+        assertFalse(item.matchesSearch("nested"))
+    }
+
+    @Test
+    fun `matchesSearch accepts empty query`() {
+        val item = KeeperListPickerItem("Anything", KeeperVaultBadge.NESTED)
+        assertTrue(item.matchesSearch(""))
+    }
+}

--- a/src/test/kotlin/keepersecurity/util/KeeperCliSafetyTest.kt
+++ b/src/test/kotlin/keepersecurity/util/KeeperCliSafetyTest.kt
@@ -1,0 +1,67 @@
+package keepersecurity.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeeperCliSafetyTest {
+
+    @Test fun `requireSafe accepts a plain single-line value`() {
+        assertEquals("hello", KeeperCliSafety.requireSafe("hello", "title"))
+    }
+
+    @Test fun `requireSafe accepts spaces, tabs, and quotes`() {
+        val v = "a value with \"quotes\" and a\ttab"
+        assertEquals(v, KeeperCliSafety.requireSafe(v, "selected text"))
+    }
+
+    @Test fun `requireSafe rejects an embedded LF`() {
+        val ex = assertThrows(KeeperCliSafety.UnsafeCliInputException::class.java) {
+            KeeperCliSafety.requireSafe("foo\nthis-device rename PWNED", "selected text")
+        }
+        assertTrue(ex.message!!.contains("selected text"))
+    }
+
+    @Test fun `requireSafe rejects an embedded CR`() {
+        assertThrows(KeeperCliSafety.UnsafeCliInputException::class.java) {
+            KeeperCliSafety.requireSafe("foo\rbad", "title")
+        }
+    }
+
+    @Test fun `requireSafe rejects an embedded NUL`() {
+        assertThrows(KeeperCliSafety.UnsafeCliInputException::class.java) {
+            KeeperCliSafety.requireSafe("foo\u0000bad", "field name")
+        }
+    }
+
+    @Test fun `assertSingleLine accepts a single-line command`() {
+        KeeperCliSafety.assertSingleLine("record-add --title=\"x\" password=\"y\"")
+    }
+
+    @Test fun `assertSingleLine rejects an embedded LF in the assembled command`() {
+        assertThrows(KeeperCliSafety.UnsafeCliInputException::class.java) {
+            KeeperCliSafety.assertSingleLine("record-add\nthis-device rename PWNED")
+        }
+    }
+
+    @Test fun `isValidRecordUid accepts a 22-char URL-safe Base64 uid`() {
+        assertTrue(KeeperCliSafety.isValidRecordUid("abc123def456GHI789jkLM"))
+    }
+
+    @Test fun `isValidRecordUid rejects placeholder and short uids`() {
+        assertFalse(KeeperCliSafety.isValidRecordUid("REPLACE_WITH_REAL_UID"))
+        assertFalse(KeeperCliSafety.isValidRecordUid("abc"))
+    }
+
+    @Test fun `isValidRecordUid rejects too-long and invalid-character uids`() {
+        assertFalse(KeeperCliSafety.isValidRecordUid("abc123def456GHI789jkLMx"))
+        assertFalse(KeeperCliSafety.isValidRecordUid("abc123def456GHI789jk!M"))
+    }
+
+    @Test fun `KEEPER_RECORD_UID regex matches only full 22-char uids`() {
+        assertTrue(KeeperCliSafety.KEEPER_RECORD_UID.matches("2zHC3Umb41PnVECFZxYTXw"))
+        assertFalse(KeeperCliSafety.KEEPER_RECORD_UID.matches("prefix2zHC3Umb41PnVECFZxYTXw"))
+    }
+}

--- a/src/test/kotlin/keepersecurity/util/KeeperCliSafetyTest.kt
+++ b/src/test/kotlin/keepersecurity/util/KeeperCliSafetyTest.kt
@@ -64,4 +64,13 @@ class KeeperCliSafetyTest {
         assertTrue(KeeperCliSafety.KEEPER_RECORD_UID.matches("2zHC3Umb41PnVECFZxYTXw"))
         assertFalse(KeeperCliSafety.KEEPER_RECORD_UID.matches("prefix2zHC3Umb41PnVECFZxYTXw"))
     }
+
+    @Test fun `escapeDoubleQuoted escapes backslashes and double quotes`() {
+        assertEquals("foo\\\"bar", KeeperCliSafety.escapeDoubleQuoted("foo\"bar"))
+        assertEquals("back\\\\slash", KeeperCliSafety.escapeDoubleQuoted("back\\slash"))
+    }
+
+    @Test fun `escapeSingleQuoted escapes embedded single quotes`() {
+        assertEquals("it'\\''s", KeeperCliSafety.escapeSingleQuoted("it's"))
+    }
 }

--- a/src/test/kotlin/keepersecurity/util/KeeperEnvSafetyTest.kt
+++ b/src/test/kotlin/keepersecurity/util/KeeperEnvSafetyTest.kt
@@ -1,0 +1,72 @@
+package keepersecurity.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeeperEnvSafetyTest {
+
+    @Test fun `blockedEnvKeyReason rejects NODE_OPTIONS`() {
+        assertTrue(KeeperEnvSafety.blockedEnvKeyReason("NODE_OPTIONS")!!.contains("blocked"))
+    }
+
+    @Test fun `blockedEnvKeyReason rejects case-insensitive exact keys`() {
+        assertTrue(KeeperEnvSafety.blockedEnvKeyReason("node_options")!!.contains("blocked"))
+    }
+
+    @Test fun `blockedEnvKeyReason rejects DYLD_INSERT_LIBRARIES`() {
+        assertTrue(KeeperEnvSafety.blockedEnvKeyReason("DYLD_INSERT_LIBRARIES")!!.contains("DYLD"))
+    }
+
+    @Test fun `blockedEnvKeyReason rejects suffix _OPTIONS`() {
+        assertTrue(KeeperEnvSafety.blockedEnvKeyReason("FOO_OPTIONS")!!.contains("_OPTIONS"))
+    }
+
+    @Test fun `blockedEnvKeyReason rejects suffix _DEBUGGER`() {
+        assertTrue(KeeperEnvSafety.blockedEnvKeyReason("MY_DEBUGGER")!!.contains("_DEBUGGER"))
+    }
+
+    @Test fun `blockedEnvKeyReason allows routine secret keys`() {
+        assertNull(KeeperEnvSafety.blockedEnvKeyReason("DATABASE_PASSWORD"))
+        assertNull(KeeperEnvSafety.blockedEnvKeyReason("API_TOKEN"))
+        assertNull(KeeperEnvSafety.blockedEnvKeyReason("APP_NAME"))
+    }
+
+    @Test fun `blockedEnvValueReason rejects interpreter flag values`() {
+        assertTrue(
+            KeeperEnvSafety.blockedEnvValueReason("--require=./pwn.js")!!.contains("interpreter flag")
+        )
+    }
+
+    @Test fun `blockedEnvValueReason rejects command substitution`() {
+        assertTrue(KeeperEnvSafety.blockedEnvValueReason("$(whoami)")!!.contains("substitution"))
+        assertTrue(KeeperEnvSafety.blockedEnvValueReason("`id`")!!.contains("substitution"))
+    }
+
+    @Test fun `blockedEnvValueReason rejects control characters`() {
+        assertTrue(KeeperEnvSafety.blockedEnvValueReason("secret\nbad")!!.contains("control"))
+        assertTrue(KeeperEnvSafety.blockedEnvValueReason("secret\rbad")!!.contains("control"))
+        assertTrue(KeeperEnvSafety.blockedEnvValueReason("secret\u0000bad")!!.contains("control"))
+    }
+
+    @Test fun `blockedEnvValueReason allows normal secret values`() {
+        assertNull(KeeperEnvSafety.blockedEnvValueReason("super-secret-password"))
+        assertNull(KeeperEnvSafety.blockedEnvValueReason("sk-live-abc123"))
+    }
+
+    @Test fun `validateForInjection blocks PoC NODE_OPTIONS payload`() {
+        val verdict = KeeperEnvSafety.validateForInjection("NODE_OPTIONS", "--require=./pwn.js")
+        assertTrue(verdict is KeeperEnvSafety.Verdict.Blocked)
+        assertEquals("NODE_OPTIONS", (verdict as KeeperEnvSafety.Verdict.Blocked).key)
+    }
+
+    @Test fun `validateForInjection allows normal DATABASE_URL injection`() {
+        val verdict = KeeperEnvSafety.validateForInjection("DATABASE_URL", "postgres://localhost/db")
+        assertTrue(verdict is KeeperEnvSafety.Verdict.Allowed)
+        assertEquals(
+            "postgres://localhost/db",
+            (verdict as KeeperEnvSafety.Verdict.Allowed).value,
+        )
+    }
+}

--- a/src/test/kotlin/keepersecurity/util/KeeperEnvSafetyTest.kt
+++ b/src/test/kotlin/keepersecurity/util/KeeperEnvSafetyTest.kt
@@ -33,10 +33,10 @@ class KeeperEnvSafetyTest {
         assertNull(KeeperEnvSafety.blockedEnvKeyReason("APP_NAME"))
     }
 
-    @Test fun `blockedEnvValueReason rejects interpreter flag values`() {
-        assertTrue(
-            KeeperEnvSafety.blockedEnvValueReason("--require=./pwn.js")!!.contains("interpreter flag")
-        )
+    @Test fun `blockedEnvValueReason allows flag-like secret values`() {
+        assertNull(KeeperEnvSafety.blockedEnvValueReason("--require=./pwn.js"))
+        assertNull(KeeperEnvSafety.blockedEnvValueReason("-Dtimezone=UTC"))
+        assertNull(KeeperEnvSafety.blockedEnvValueReason("-Xmx4g"))
     }
 
     @Test fun `blockedEnvValueReason rejects command substitution`() {
@@ -68,5 +68,23 @@ class KeeperEnvSafetyTest {
             "postgres://localhost/db",
             (verdict as KeeperEnvSafety.Verdict.Allowed).value,
         )
+    }
+
+    @Test fun `buildSubprocessEnvironment drops inherited hook vars and keeps PATH`() {
+        val inherited = mapOf(
+            "PATH" to "/usr/bin",
+            "HOME" to "/Users/test",
+            "NODE_OPTIONS" to "--require=./evil.js",
+            "LD_PRELOAD" to "/tmp/pwn.so",
+        )
+        val injected = mapOf("DATABASE_URL" to "postgres://localhost/db")
+
+        val env = KeeperEnvSafety.buildSubprocessEnvironment(inherited, injected, isWindows = false)
+
+        assertEquals("postgres://localhost/db", env["DATABASE_URL"])
+        assertEquals("/usr/bin", env["PATH"])
+        assertEquals("/Users/test", env["HOME"])
+        assertNull(env["NODE_OPTIONS"])
+        assertNull(env["LD_PRELOAD"])
     }
 }

--- a/src/test/kotlin/keepersecurity/util/KeeperFolderValidatorTest.kt
+++ b/src/test/kotlin/keepersecurity/util/KeeperFolderValidatorTest.kt
@@ -1,0 +1,164 @@
+package keepersecurity.util
+
+import keepersecurity.model.KeeperFolder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure-function side of [KeeperFolderValidator].
+ *
+ * The CLI-touching `verifyBlocking` / `verifySavedFolder` paths require a
+ * live shell and aren't covered here — the action-level smoke tests in
+ * `KeeperActionTestSuite` exercise them through the mocked shell. Here we
+ * just cover [KeeperFolderValidator.classify], which is the bit that
+ * decides Valid vs Missing vs Mismatch from a parsed folder list.
+ */
+class KeeperFolderValidatorTest {
+
+    private fun classicFolder(uid: String, name: String) =
+        KeeperFolder(folderUid = uid, name = name, type = null, source = KeeperFolder.SOURCE_CLASSIC_FOLDER)
+
+    private fun nestedShareFolder(uid: String, name: String) =
+        KeeperFolder(folderUid = uid, name = name, type = null, source = KeeperFolder.SOURCE_NESTED_SHARE_FOLDER)
+
+    /** Legacy Commander wire values — kept for backward compatibility in tests. */
+    private fun legacyClassicFolder(uid: String, name: String) =
+        KeeperFolder(folderUid = uid, name = name, type = null, source = "Legacy")
+
+    private fun legacyNestedShareFolder(uid: String, name: String) =
+        KeeperFolder(folderUid = uid, name = name, type = null, source = "KeeperDrive")
+
+    @Test
+    fun `classify returns Valid for classic UUID present in the classic slot`() {
+        val folders = listOf(
+            classicFolder("classic-1", "Demo Folder"),
+            nestedShareFolder("drive-1", "Nested Shared Folder")
+        )
+
+        val verdict = KeeperFolderValidator.classify(
+            folders = folders,
+            uuid = "classic-1",
+            expected = KeeperFolderValidator.ExpectedKind.CLASSIC
+        )
+
+        assertTrue("Should be Valid", verdict is KeeperFolderValidator.Verdict.Valid)
+        verdict as KeeperFolderValidator.Verdict.Valid
+        assertEquals("classic-1", verdict.uuid)
+        assertEquals("Demo Folder", verdict.name)
+        assertEquals(false, verdict.isDrive)
+    }
+
+    @Test
+    fun `classify returns Valid for Nested Shared Folder UUID present in the drive slot`() {
+        val folders = listOf(
+            classicFolder("classic-1", "Demo Folder"),
+            nestedShareFolder("drive-1", "Nested Shared Folder")
+        )
+
+        val verdict = KeeperFolderValidator.classify(
+            folders = folders,
+            uuid = "drive-1",
+            expected = KeeperFolderValidator.ExpectedKind.DRIVE
+        )
+
+        assertTrue("Should be Valid", verdict is KeeperFolderValidator.Verdict.Valid)
+        verdict as KeeperFolderValidator.Verdict.Valid
+        assertEquals("drive-1", verdict.uuid)
+        assertEquals("Nested Shared Folder", verdict.name)
+        assertEquals(true, verdict.isDrive)
+    }
+
+    @Test
+    fun `classify returns Missing when the UUID isn't in the listing`() {
+        val folders = listOf(classicFolder("classic-1", "Demo Folder"))
+
+        val verdict = KeeperFolderValidator.classify(
+            folders = folders,
+            uuid = "ghost-uuid",
+            expected = KeeperFolderValidator.ExpectedKind.CLASSIC
+        )
+
+        assertTrue("Should be Missing", verdict is KeeperFolderValidator.Verdict.Missing)
+    }
+
+    @Test
+    fun `classify returns Mismatch when a classic UUID resolves to a Nested Shared Folder`() {
+        // Saved as Classic but the folder it points at is actually a Nested Shared Folder.
+        val folders = listOf(nestedShareFolder("drive-1", "Promoted Folder"))
+
+        val verdict = KeeperFolderValidator.classify(
+            folders = folders,
+            uuid = "drive-1",
+            expected = KeeperFolderValidator.ExpectedKind.CLASSIC
+        )
+
+        assertTrue("Should be Mismatch", verdict is KeeperFolderValidator.Verdict.Mismatch)
+        verdict as KeeperFolderValidator.Verdict.Mismatch
+        assertEquals(KeeperFolderValidator.ExpectedKind.DRIVE, verdict.actualKind)
+        assertEquals("Promoted Folder", verdict.name)
+    }
+
+    @Test
+    fun `classify returns Mismatch when a Nested Shared Folder UUID resolves to a Classic folder`() {
+        val folders = listOf(classicFolder("classic-1", "Old Folder"))
+
+        val verdict = KeeperFolderValidator.classify(
+            folders = folders,
+            uuid = "classic-1",
+            expected = KeeperFolderValidator.ExpectedKind.DRIVE
+        )
+
+        assertTrue("Should be Mismatch", verdict is KeeperFolderValidator.Verdict.Mismatch)
+        verdict as KeeperFolderValidator.Verdict.Mismatch
+        assertEquals(KeeperFolderValidator.ExpectedKind.CLASSIC, verdict.actualKind)
+        assertEquals("Old Folder", verdict.name)
+    }
+
+    @Test
+    fun `classify recognizes nested_share_folder UUID from current Commander ls output`() {
+        val folders = listOf(
+            classicFolder("y2cG8GbSF3k_TT0D-EOH1w", "kcm-creds"),
+            nestedShareFolder("2zHC3Umb41PnVECFZxYTXw", "Keeper Drive Test folder"),
+        )
+
+        val verdict = KeeperFolderValidator.classify(
+            folders = folders,
+            uuid = "2zHC3Umb41PnVECFZxYTXw",
+            expected = KeeperFolderValidator.ExpectedKind.DRIVE,
+        )
+
+        assertTrue(verdict is KeeperFolderValidator.Verdict.Valid)
+        verdict as KeeperFolderValidator.Verdict.Valid
+        assertEquals(true, verdict.isDrive)
+    }
+
+    @Test
+    fun `classify treats classic_folder UUID as Classic not Nested Shared Folder`() {
+        val folders = listOf(
+            classicFolder("y2cG8GbSF3k_TT0D-EOH1w", "kcm-creds"),
+            nestedShareFolder("2zHC3Umb41PnVECFZxYTXw", "Keeper Drive Test folder"),
+        )
+
+        val verdict = KeeperFolderValidator.classify(
+            folders = folders,
+            uuid = "y2cG8GbSF3k_TT0D-EOH1w",
+            expected = KeeperFolderValidator.ExpectedKind.CLASSIC,
+        )
+
+        assertTrue(verdict is KeeperFolderValidator.Verdict.Valid)
+        verdict as KeeperFolderValidator.Verdict.Valid
+        assertEquals(false, verdict.isDrive)
+    }
+
+    @Test
+    fun `classify on empty list is always Missing`() {
+        val verdict = KeeperFolderValidator.classify(
+            folders = emptyList(),
+            uuid = "any",
+            expected = KeeperFolderValidator.ExpectedKind.CLASSIC
+        )
+
+        assertTrue("Should be Missing", verdict is KeeperFolderValidator.Verdict.Missing)
+    }
+}

--- a/src/test/kotlin/keepersecurity/util/KeeperRecordOutputValidatorsTest.kt
+++ b/src/test/kotlin/keepersecurity/util/KeeperRecordOutputValidatorsTest.kt
@@ -1,0 +1,211 @@
+package keepersecurity.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [KeeperRecordOutputValidators]. Covers classic and Nested
+ * Share Subfolders (`nsf-*`) success outputs plus the well-known failure modes
+ * from Commander (sync banners, BreachWatch hints, nsf-record-add warning
+ * aborts, unknown-command errors on older builds).
+ */
+class KeeperRecordOutputValidatorsTest {
+
+    // --- isRecordAddSuccess -------------------------------------------------
+
+    @Test
+    fun `record-add succeeds with bare UID output`() {
+        assertTrue(KeeperRecordOutputValidators.isRecordAddSuccess("abc123def456GHI789jkLM"))
+    }
+
+    @Test
+    fun `record-add succeeds with Commander wrapping the UID in a sentence`() {
+        val output = "Record UID: abc123def456GHI789jkLM"
+        assertTrue(KeeperRecordOutputValidators.isRecordAddSuccess(output))
+    }
+
+    @Test
+    fun `nsf-record-add succeeds with Commander v3 success line`() {
+        val output = "Created Nested Shared record abc123def456GHI789jkLM"
+        assertTrue(KeeperRecordOutputValidators.isRecordAddSuccess(output))
+    }
+
+    @Test
+    fun `record-add rejects empty output`() {
+        assertFalse(KeeperRecordOutputValidators.isRecordAddSuccess(""))
+    }
+
+    @Test
+    fun `record-add rejects sync-banner output even when a UID-shaped token is present`() {
+        val output = "Decrypted [12] record(s) abc123def456GHI789jkLM"
+        assertFalse(KeeperRecordOutputValidators.isRecordAddSuccess(output))
+    }
+
+    @Test
+    fun `record-add rejects breachwatch hint`() {
+        val output = "Use \"breachwatch list\" command to inspect recent activity"
+        assertFalse(KeeperRecordOutputValidators.isRecordAddSuccess(output))
+    }
+
+    @Test
+    fun `record-add rejects explicit CLI error`() {
+        val output = "Error: invalid record type 'login2'"
+        assertFalse(KeeperRecordOutputValidators.isRecordAddSuccess(output))
+    }
+
+    @Test
+    fun `nsf-record-add rejects warning-aborted output (no -f)`() {
+        val output =
+            "Warning: attachment fields are not supported in nsf-record-add; rerun with -f to skip"
+        assertFalse(KeeperRecordOutputValidators.isRecordAddSuccess(output))
+    }
+
+    @Test
+    fun `nsf-record-add rejects unknown-command error on older Commander`() {
+        val output = "Unknown command: nsf-record-add"
+        assertFalse(KeeperRecordOutputValidators.isRecordAddSuccess(output))
+    }
+
+    @Test
+    fun `record-add rejects output with no UID-shaped token`() {
+        val output = "Operation completed"
+        assertFalse(KeeperRecordOutputValidators.isRecordAddSuccess(output))
+    }
+
+    // --- isRecordUpdateSuccess ---------------------------------------------
+
+    @Test
+    fun `record-update accepts empty output as success`() {
+        assertTrue(KeeperRecordOutputValidators.isRecordUpdateSuccess(""))
+    }
+
+    @Test
+    fun `record-update accepts a short success line`() {
+        assertTrue(KeeperRecordOutputValidators.isRecordUpdateSuccess("Updated 1 record"))
+    }
+
+    @Test
+    fun `nsf-record-update accepts nsf-flavoured success line`() {
+        assertTrue(
+            KeeperRecordOutputValidators.isRecordUpdateSuccess(
+                "nsf-record-update succeeded for rvwIBG_ban2VTH64OsnzLn"
+            )
+        )
+    }
+
+    @Test
+    fun `record-update rejects sync banner`() {
+        val output = "Decrypted [42] record(s)"
+        assertFalse(KeeperRecordOutputValidators.isRecordUpdateSuccess(output))
+    }
+
+    @Test
+    fun `record-update rejects CLI error string`() {
+        val output = "Record not found: abc123"
+        assertFalse(KeeperRecordOutputValidators.isRecordUpdateSuccess(output))
+    }
+
+    @Test
+    fun `nsf-record-update rejects unknown-command failure on older Commander`() {
+        val output = "Unknown command: nsf-record-update"
+        assertFalse(KeeperRecordOutputValidators.isRecordUpdateSuccess(output))
+    }
+
+    @Test
+    fun `record-update rejects warning prefix from nsf-record-add style abort`() {
+        val output = "Warning: unsupported field 'attachments'"
+        assertFalse(KeeperRecordOutputValidators.isRecordUpdateSuccess(output))
+    }
+
+    // --- helper detectors --------------------------------------------------
+
+    @Test
+    fun `isSyncBanner detects every known marker case-sensitively`() {
+        assertTrue(KeeperRecordOutputValidators.isSyncBanner("Decrypted [3]"))
+        assertTrue(KeeperRecordOutputValidators.isSyncBanner("synced record(s)"))
+        assertTrue(KeeperRecordOutputValidators.isSyncBanner("Use \"breachwatch list\" command"))
+        assertFalse(KeeperRecordOutputValidators.isSyncBanner("nothing to see here"))
+    }
+
+    @Test
+    fun `looksLikeError ignores case`() {
+        assertTrue(KeeperRecordOutputValidators.looksLikeError("ERROR: bad input"))
+        assertTrue(KeeperRecordOutputValidators.looksLikeError("Failed to authenticate"))
+        assertTrue(KeeperRecordOutputValidators.looksLikeError("Aborted by user"))
+        assertFalse(KeeperRecordOutputValidators.looksLikeError("Record created"))
+    }
+
+    // --- extractRecordUid --------------------------------------------------
+
+    @Test
+    fun `extractRecordUid returns the first 22-char UID in the output`() {
+        val uid = "abc123def456GHI789jkLM"
+        assertEquals(uid, KeeperRecordOutputValidators.extractRecordUid("created uid=$uid"))
+    }
+
+    @Test
+    fun `extractRecordUid returns null when no UID-shaped token is present`() {
+        assertNull(KeeperRecordOutputValidators.extractRecordUid("short text"))
+    }
+
+    // --- isFatalError ------------------------------------------------------
+
+    @Test
+    fun `isFatalError flags Commander's catch-all unexpected error`() {
+        val output = "An unexpected error occurred: No module named 'keepercommander.keeper_drive.folder_api'."
+        assertTrue(KeeperRecordOutputValidators.isFatalError(output))
+    }
+
+    @Test
+    fun `isFatalError flags Python ModuleNotFoundError tracebacks`() {
+        val output = "ModuleNotFoundError: No module named 'keepercommander.keeper_drive.folder_api'"
+        assertTrue(KeeperRecordOutputValidators.isFatalError(output))
+    }
+
+    @Test
+    fun `isFatalError flags older Commander unknown-command output`() {
+        assertTrue(KeeperRecordOutputValidators.isFatalError("Unknown command: nsf-record-add"))
+    }
+
+    @Test
+    fun `isFatalError flags not-logged-in state`() {
+        assertTrue(KeeperRecordOutputValidators.isFatalError("You are not logged in"))
+    }
+
+    @Test
+    fun `isFatalError ignores generic transient errors that can recover on retry`() {
+        // BreachWatch / sync banners are noisy but recoverable — they must
+        // *not* short-circuit the retry loop.
+        assertFalse(KeeperRecordOutputValidators.isFatalError("Decrypted [91] records"))
+        assertFalse(KeeperRecordOutputValidators.isFatalError("Use \"breachwatch list\" command"))
+    }
+
+    @Test
+    fun `isFatalError is case-insensitive`() {
+        assertTrue(KeeperRecordOutputValidators.isFatalError("AN UNEXPECTED ERROR OCCURRED"))
+        assertTrue(KeeperRecordOutputValidators.isFatalError("Not Logged In"))
+    }
+
+    // --- summariseError ----------------------------------------------------
+
+    @Test
+    fun `summariseError strips Commander prompts and debug trailer`() {
+        val raw = "My Vault> An unexpected error occurred: boom. Type \"debug\" to toggle verbose error output"
+        val summary = KeeperRecordOutputValidators.summariseError(raw)
+        assertFalse("Should drop the My Vault prompt", summary.contains("My Vault>"))
+        assertFalse("Should drop the debug trailer", summary.contains("toggle verbose"))
+        assertTrue("Should keep the real error sentence", summary.contains("An unexpected error occurred"))
+    }
+
+    @Test
+    fun `summariseError caps long outputs at a sensible length`() {
+        val raw = "Error: " + "x".repeat(1000)
+        val summary = KeeperRecordOutputValidators.summariseError(raw)
+        assertTrue("Summary should be capped to 300 chars", summary.length <= 300)
+        assertNotEquals(raw, summary)
+    }
+}

--- a/src/test/kotlin/keepersecurity/util/KeeperRecordOutputValidatorsTest.kt
+++ b/src/test/kotlin/keepersecurity/util/KeeperRecordOutputValidatorsTest.kt
@@ -121,6 +121,12 @@ class KeeperRecordOutputValidatorsTest {
         assertFalse(KeeperRecordOutputValidators.isRecordUpdateSuccess(output))
     }
 
+    @Test
+    fun `record-update accepts success line containing word invalid`() {
+        val output = "1 record(s) updated (skipped: 2 invalid fields)"
+        assertTrue(KeeperRecordOutputValidators.isRecordUpdateSuccess(output))
+    }
+
     // --- helper detectors --------------------------------------------------
 
     @Test

--- a/src/test/kotlin/keepersecurity/util/KeeperRecordValidatorTest.kt
+++ b/src/test/kotlin/keepersecurity/util/KeeperRecordValidatorTest.kt
@@ -1,0 +1,128 @@
+package keepersecurity.util
+
+import keepersecurity.model.KeeperRecord
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure-function side of [KeeperRecordValidator].
+ *
+ * The CLI-touching `lookupBlocking` / `lookupRecord` paths require a
+ * live shell and aren't covered here — the action-level smoke tests in
+ * `KeeperActionTestSuite` exercise them through the mocked shell. Here
+ * we cover [KeeperRecordValidator.classify], which decides Found vs
+ * NotFound from a parsed record list.
+ */
+class KeeperRecordValidatorTest {
+
+    private fun classicRecord(uid: String, title: String) =
+        KeeperRecord(recordUid = uid, title = title, recordCategory = KeeperRecord.CATEGORY_CLASSIC)
+
+    private fun nestedShareRecord(uid: String, title: String) =
+        KeeperRecord(recordUid = uid, title = title, recordCategory = KeeperRecord.CATEGORY_NESTED)
+
+    /** Legacy Commander wire value — kept for backward compatibility in tests. */
+    private fun legacyNestedShareRecord(uid: String, title: String) =
+        KeeperRecord(recordUid = uid, title = title, recordCategory = "KeeperDrive")
+
+    private fun legacyRecord(uid: String, title: String) =
+        KeeperRecord(recordUid = uid, title = title, recordCategory = null)
+
+    @Test
+    fun `classify routes a classic record to Found with CLASSIC kind`() {
+        val records = listOf(
+            classicRecord("classic-1", "Demo Login"),
+            nestedShareRecord("drive-1", "Nested Shared Login")
+        )
+
+        val verdict = KeeperRecordValidator.classify(records, "classic-1")
+        assertTrue("Should be Found", verdict is KeeperRecordValidator.Verdict.Found)
+        verdict as KeeperRecordValidator.Verdict.Found
+        assertEquals(KeeperRecordValidator.Kind.CLASSIC, verdict.kind)
+        assertEquals("classic-1", verdict.uuid)
+        assertEquals("Demo Login", verdict.title)
+    }
+
+    @Test
+    fun `classify routes a Nested Shared record to Found with DRIVE kind`() {
+        val records = listOf(
+            classicRecord("classic-1", "Demo Login"),
+            nestedShareRecord("drive-1", "Nested Shared Login")
+        )
+
+        val verdict = KeeperRecordValidator.classify(records, "drive-1")
+        assertTrue("Should be Found", verdict is KeeperRecordValidator.Verdict.Found)
+        verdict as KeeperRecordValidator.Verdict.Found
+        assertEquals(KeeperRecordValidator.Kind.DRIVE, verdict.kind)
+        assertEquals("drive-1", verdict.uuid)
+        assertEquals("Nested Shared Login", verdict.title)
+    }
+
+    @Test
+    fun `classify defaults legacy records (no record_category) to CLASSIC`() {
+        // Older Commander releases that pre-date the v3 API don't
+        // populate `record_category`. Defaulting to Classic keeps the
+        // Update flow working unchanged for those vaults; the cost of
+        // a wrong guess is the same "record not found" the user would
+        // have seen with the old explicit prompt, just one round-trip
+        // later.
+        val records = listOf(legacyRecord("legacy-1", "Old Login"))
+
+        val verdict = KeeperRecordValidator.classify(records, "legacy-1")
+        assertTrue("Should be Found", verdict is KeeperRecordValidator.Verdict.Found)
+        verdict as KeeperRecordValidator.Verdict.Found
+        assertEquals(KeeperRecordValidator.Kind.CLASSIC, verdict.kind)
+    }
+
+    @Test
+    fun `classify returns NotFound when the UID isn't in the listing`() {
+        val records = listOf(classicRecord("classic-1", "Demo Login"))
+
+        val verdict = KeeperRecordValidator.classify(records, "ghost-uid")
+        assertTrue("Should be NotFound", verdict is KeeperRecordValidator.Verdict.NotFound)
+    }
+
+    @Test
+    fun `classify recognizes Nested record_category from current Commander list output`() {
+        val records = listOf(
+            classicRecord("JrdTfqy4sp6WFzZ4cov9TQ", "iTerm2ClassicRec"),
+            nestedShareRecord("FnxkikNsz2W7OyqDB9fTAg", "iTerm2NSFRec"),
+        )
+
+        val verdict = KeeperRecordValidator.classify(records, "FnxkikNsz2W7OyqDB9fTAg")
+        assertTrue(verdict is KeeperRecordValidator.Verdict.Found)
+        verdict as KeeperRecordValidator.Verdict.Found
+        assertEquals(KeeperRecordValidator.Kind.DRIVE, verdict.kind)
+        assertEquals("iTerm2NSFRec", verdict.title)
+    }
+
+    @Test
+    fun `classify treats Classic record_category as Classic vault`() {
+        val records = listOf(
+            classicRecord("JrdTfqy4sp6WFzZ4cov9TQ", "iTerm2ClassicRec"),
+            nestedShareRecord("FnxkikNsz2W7OyqDB9fTAg", "iTerm2NSFRec"),
+        )
+
+        val verdict = KeeperRecordValidator.classify(records, "JrdTfqy4sp6WFzZ4cov9TQ")
+        assertTrue(verdict is KeeperRecordValidator.Verdict.Found)
+        verdict as KeeperRecordValidator.Verdict.Found
+        assertEquals(KeeperRecordValidator.Kind.CLASSIC, verdict.kind)
+    }
+
+    @Test
+    fun `classify on empty list is always NotFound`() {
+        val verdict = KeeperRecordValidator.classify(emptyList(), "any")
+        assertTrue("Should be NotFound", verdict is KeeperRecordValidator.Verdict.NotFound)
+    }
+
+    @Test
+    fun `classify falls back to the UID when the record has a blank title`() {
+        val records = listOf(classicRecord("classic-1", ""))
+
+        val verdict = KeeperRecordValidator.classify(records, "classic-1")
+        assertTrue("Should be Found", verdict is KeeperRecordValidator.Verdict.Found)
+        verdict as KeeperRecordValidator.Verdict.Found
+        assertEquals("classic-1", verdict.title)
+    }
+}


### PR DESCRIPTION
## Summary
- Nested Shared Folder support across Get Folder/Secret, Add/Update/Generate Record with automatic `record-*` vs `nsf-*` routing
- Searchable folder/record picker with Classic / Nested badges
- Folder and record UID validation before CLI calls
- Run Keeper Securely hardening: env injection controls and `keeper://` UID format validation
- CLI input sanitization for editor selections passed to the persistent Commander shell
## Test plan
- [ ] CI `./gradlew test` passes
- [ ] `buildPlugin` → Install from Disk in IntelliJ IDEA (CE or Ultimate)
- [ ] Check Keeper Authorization
- [ ] Get Keeper Folder / Get Keeper Secret (badges, search)
- [ ] Add / Update / Generate record (Classic vs Nested routing)
- [ ] Run Keeper Securely with valid and invalid `keeper://` UIDs
- [ ] (Ultimate only) Get Keeper Secret in a `.http` file — HTTP Client snippet inserts correctly