### PR TITLE
release: v2.0.1 - Marketplace rejection fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginGroup = com.keepersecurity.jetbrains
 pluginName = Keeper Security
 pluginRepositoryUrl = https://github.com/Keeper-Security/keeper-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.0
+pluginVersion = 2.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243

--- a/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
@@ -5,6 +5,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
@@ -328,17 +330,19 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
     }
 
     /**
-     * Detects JetBrains HTTP Client request files by extension. Avoids internal platform APIs
-     * (`PluginManagerCore`, `HttpRequestFileType`); the `$keeper` dynamic variable is registered
-     * only when the optional `com.jetbrains.restClient` dependency is loaded.
-     */
+    * Detects JetBrains HTTP Client request files by extension when the HTTP Client plugin is
+    * installed. Uses public [PluginManager.isPluginInstalled] (not Internal API
+    * [com.intellij.ide.plugins.PluginManagerCore.getPlugin]). The `$keeper` dynamic variable is
+    * registered only when optional `com.jetbrains.restClient` loads `keeper-http-client.xml`.
+    */
     private fun isHttpClientRequestFile(editor: Editor): Boolean {
         val file: VirtualFile = FileDocumentManager.getInstance().getFile(editor.document) ?: return false
-        return when (file.extension?.lowercase()) {
-            "http", "rest" -> true
-            else -> false
-        }
+        if (!isHttpClientPluginEnabled()) return false
+        return file.extension?.lowercase() in setOf("http", "rest")
     }
+
+    private fun isHttpClientPluginEnabled(): Boolean =
+        PluginManager.isPluginInstalled(PluginId.getId("com.jetbrains.restClient"))
 
     /**
      * Snippet for HTTP Client: no space after `{{` (see JetBrains HTTP Client variable docs).

--- a/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
@@ -1,12 +1,10 @@
 package keepersecurity.action
 
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
@@ -330,23 +328,16 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
     }
 
     /**
-     * Detects HTTP Client request files via the FileType API. The `com.jetbrains.restClient`
-     * plugin is an optional dependency, so its classes are only on the classpath when it is
-     * loaded; the plugin check plus the try/catch keep the call safe on IDEs that do not bundle it.
+     * Detects JetBrains HTTP Client request files by extension. Avoids internal platform APIs
+     * (`PluginManagerCore`, `HttpRequestFileType`); the `$keeper` dynamic variable is registered
+     * only when the optional `com.jetbrains.restClient` dependency is loaded.
      */
     private fun isHttpClientRequestFile(editor: Editor): Boolean {
         val file: VirtualFile = FileDocumentManager.getInstance().getFile(editor.document) ?: return false
-        if (!isHttpClientPluginEnabled()) return false
-        return try {
-            file.fileType == com.intellij.httpClient.http.request.HttpRequestFileType.INSTANCE
-        } catch (_: Throwable) {
-            false
+        return when (file.extension?.lowercase()) {
+            "http", "rest" -> true
+            else -> false
         }
-    }
-
-    private fun isHttpClientPluginEnabled(): Boolean {
-        val descriptor = PluginManagerCore.getPlugin(PluginId.getId("com.jetbrains.restClient"))
-        return descriptor != null && descriptor.isEnabled
     }
 
     /**

--- a/src/main/kotlin/keepersecurity/run/KeeperSecureRunConfigurationType.kt
+++ b/src/main/kotlin/keepersecurity/run/KeeperSecureRunConfigurationType.kt
@@ -4,6 +4,7 @@ import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationTypeBase
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.configurations.RunConfigurationOptions
+import com.intellij.execution.configurations.RunConfigurationSingletonPolicy
 import com.intellij.openapi.project.Project
 import com.intellij.icons.AllIcons
 
@@ -27,6 +28,7 @@ class KeeperSecureRunConfigurationType : ConfigurationTypeBase(
 
         override fun getName(): String = "Run Keeper Securely"
 
-        override fun isConfigurationSingletonByDefault(): Boolean = false
+        override fun getSingletonPolicy(): RunConfigurationSingletonPolicy =
+            RunConfigurationSingletonPolicy.MULTIPLE_INSTANCE
     }
 }

--- a/src/main/kotlin/keepersecurity/ui/KeeperListPickerDialog.kt
+++ b/src/main/kotlin/keepersecurity/ui/KeeperListPickerDialog.kt
@@ -251,7 +251,7 @@ object KeeperListPickerDialog {
         }
 
         private fun nestedBadgeBackground(): Color =
-            JBUI.CurrentTheme.Link.linkColor().let { link ->
+            JBUI.CurrentTheme.Link.Foreground.ENABLED.let { link ->
                 Color(
                     (link.red + 255 * 4) / 5,
                     (link.green + 255 * 4) / 5,
@@ -260,6 +260,6 @@ object KeeperListPickerDialog {
                 )
             }
 
-        private fun nestedBadgeForeground(): Color = JBUI.CurrentTheme.Link.linkColor()
+        private fun nestedBadgeForeground(): Color = JBUI.CurrentTheme.Link.Foreground.ENABLED
     }
 }

--- a/src/main/resources/META-INF/keeper-python.xml
+++ b/src/main/resources/META-INF/keeper-python.xml
@@ -1,4 +1,0 @@
-<idea-plugin>
-    <!-- Loaded only when the Python plugin is present. Run Keeper Securely defaults
-         use generic Sdk APIs from the main module; no Python-specific extensions here. -->
-</idea-plugin>

--- a/src/main/resources/META-INF/keeper-python.xml
+++ b/src/main/resources/META-INF/keeper-python.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+    <!-- Loaded only when the Python plugin is present. Run Keeper Securely defaults
+         use generic Sdk APIs from the main module; no Python-specific extensions here. -->
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,8 +4,6 @@
     <vendor email="ops@keepersecurity.com" url="https://www.keepersecurity.com">Keeper Security</vendor>
 
     <depends>com.intellij.modules.platform</depends>
-    <!-- Python: optional; enables reading project/module Python SDK for Run Keeper Securely defaults when PyCharm / Python plugin is present -->
-    <depends optional="true" config-file="keeper-python.xml">com.intellij.modules.python</depends>
     <!-- HTTP Client (Ultimate / WebStorm / etc.); optional so IC installs without it still load the plugin -->
     <depends optional="true" config-file="keeper-http-client.xml">com.jetbrains.restClient</depends>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
 
     <depends>com.intellij.modules.platform</depends>
     <!-- Python: optional; enables reading project/module Python SDK for Run Keeper Securely defaults when PyCharm / Python plugin is present -->
-    <depends optional="true">com.intellij.modules.python</depends>
+    <depends optional="true" config-file="keeper-python.xml">com.intellij.modules.python</depends>
     <!-- HTTP Client (Ultimate / WebStorm / etc.); optional so IC installs without it still load the plugin -->
     <depends optional="true" config-file="keeper-http-client.xml">com.jetbrains.restClient</depends>
 


### PR DESCRIPTION
## Summary
- Brings PR #20 fixes into main: resolves JetBrains Marketplace rejection (Internal API `PluginManagerCore.getPlugin()`) and Plugin Verifier deprecations.
- Bumps plugin version to 2.0.1.

## Changes
- `KeeperGetSecretAction`: HTTP Client file detection now uses public `PluginManager.isPluginInstalled()` with the plugin-presence guard restored, so IC/CE without the HTTP Client plugin correctly falls back to `keeper://...` instead of inserting a non-functional `{{$keeper(...)}}` snippet.
- Removed unused `com.intellij.modules.python` optional dependency and `keeper-python.xml` (no runtime effect).
- `KeeperSecureRunConfigurationType`: `RunConfigurationSingletonPolicy.MULTIPLE_INSTANCE` replaces deprecated `isConfigurationSingletonByDefault()`.
- `KeeperListPickerDialog`: `Link.Foreground.ENABLED` replaces deprecated `linkColor()`.

## Breaking Changes
None

## Test plan
- [ ] `./gradlew verifyPlugin` → Compatible
- [ ] `./gradlew test` passes
- [ ] Get Keeper Secret inserts `keeper://...` (not `{{$keeper(...)}}`) in `.http` files on IC without HTTP Client plugin