### PR TITLE
fix(marketplace): v2.0.2 -- fix deprecated/internal APIs, add 2026.2 EAP verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
 ### Fixed
 - **Commander compatibility** for current folder and record discriminators (`classic_folder` / `nested_share_folder`, `Classic` / `Nested`), with support for older wire values.
 
+## [2.0.2] - 2026-07-07
+
+### Fixed
+- Replaced internal `PluginManagerCore` API with public `PluginManager.isPluginInstalled()` for HTTP Client detection
+- Replaced deprecated `JBUI.CurrentTheme.Link.linkColor()` with `Link.Foreground.ENABLED`
+- Removed empty optional Python dependency declaration that had no runtime effect
+- Plugin now verifies compatibility against IntelliJ IDEA 2026.2 EAP (build 262.8665.81)
+
 ## [1.2.0] - 2026-06-22
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization") version "2.4.0"
     id("org.jetbrains.changelog") version "2.3.0" // Gradle Changelog Plugin
     id("org.jetbrains.qodana") version "2025.1.1" // Gradle Qodana Plugin
-    id("org.jetbrains.kotlinx.kover") version "0.9.1" // Gradle Kover Plugin
+    id("org.jetbrains.kotlinx.kover") version "0.9.8" // Gradle Kover Plugin
 }
 
 group = providers.gradleProperty("pluginGroup").get()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,9 +5,9 @@ import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
     id("java") // Java support
-    id("org.jetbrains.kotlin.jvm") version "2.2.0" // Kotlin support
+    id("org.jetbrains.kotlin.jvm") version "2.4.0" // Kotlin support
     id("org.jetbrains.intellij.platform") version "2.7.0" // IntelliJ Platform Gradle Plugin
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.2.0"
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.4.0"
     id("org.jetbrains.changelog") version "2.3.0" // Gradle Changelog Plugin
     id("org.jetbrains.qodana") version "2025.1.1" // Gradle Qodana Plugin
     id("org.jetbrains.kotlinx.kover") version "0.9.1" // Gradle Kover Plugin
@@ -121,9 +121,8 @@ intellijPlatform {
     pluginVerification {
         ides {
             ide(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
-            // Optionally verify against additional IDEs:
-            // ide("IC", "2024.3.6")
-            // ide("IU", "2024.3.6")
+            // Verify against the EAP build used by the JetBrains Marketplace live checker (build 262.8665.81 = IU 2026.2)
+            ide("IU", "262.8665.81")
         }
     }
 }
@@ -152,6 +151,16 @@ tasks {
 
     publishPlugin {
         dependsOn(patchChangelog)
+    }
+
+    // Activate the EAP trial widget so the IDE shows the same toolbar state the JetBrains
+    // Marketplace live checker uses (build IU-262.8665.81, eap.require.license=true).
+    // To test against 2026.2 EAP: set platformVersion=2026.2 in gradle.properties locally,
+    // then run ./gradlew runIde.
+    named<org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask>("runIde") {
+        jvmArgumentProviders += CommandLineArgumentProvider {
+            listOf("-Deap.require.license=true")
+        }
     }
 
     // Task to copy runtime dependencies for SBOM generation

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginGroup = com.keepersecurity.jetbrains
 pluginName = Keeper Security
 pluginRepositoryUrl = https://github.com/Keeper-Security/keeper-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.1
+pluginVersion = 2.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ pluginVersion = 2.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243
-pluginUntilBuild = 
+pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 # IU bundles HTTP Client (restClient); use IC for Community-only verification via Gradle property override

--- a/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
@@ -1,11 +1,11 @@
 package keepersecurity.action
 
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressIndicator
@@ -330,11 +330,18 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
     }
 
     /**
+<<<<<<< HEAD
     * Detects JetBrains HTTP Client request files by extension when the HTTP Client plugin is
     * installed. Uses public [PluginManager.isPluginInstalled] (not Internal API
     * [com.intellij.ide.plugins.PluginManagerCore.getPlugin]). The `$keeper` dynamic variable is
     * registered only when optional `com.jetbrains.restClient` loads `keeper-http-client.xml`.
     */
+=======
+     * Detects JetBrains HTTP Client request files by extension when the HTTP Client plugin is
+     * installed. Uses public PluginManager.isPluginInstalled (not internal PluginManagerCore).
+     * The $keeper dynamic variable is only registered when the optional restClient loads keeper-http-client.xml.
+     */
+>>>>>>> 0759420 (fix(marketplace): v2.0.2 -- fix deprecated/internal APIs, add 2026.2 EAP verification)
     private fun isHttpClientRequestFile(editor: Editor): Boolean {
         val file: VirtualFile = FileDocumentManager.getInstance().getFile(editor.document) ?: return false
         if (!isHttpClientPluginEnabled()) return false

--- a/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
+++ b/src/main/kotlin/keepersecurity/action/KeeperGetSecretAction.kt
@@ -330,18 +330,11 @@ class KeeperGetSecretAction : AnAction("Get Keeper Secret") {
     }
 
     /**
-<<<<<<< HEAD
-    * Detects JetBrains HTTP Client request files by extension when the HTTP Client plugin is
-    * installed. Uses public [PluginManager.isPluginInstalled] (not Internal API
-    * [com.intellij.ide.plugins.PluginManagerCore.getPlugin]). The `$keeper` dynamic variable is
-    * registered only when optional `com.jetbrains.restClient` loads `keeper-http-client.xml`.
-    */
-=======
      * Detects JetBrains HTTP Client request files by extension when the HTTP Client plugin is
-     * installed. Uses public PluginManager.isPluginInstalled (not internal PluginManagerCore).
-     * The $keeper dynamic variable is only registered when the optional restClient loads keeper-http-client.xml.
+     * installed. Uses public [PluginManager.isPluginInstalled] (not Internal API
+     * [com.intellij.ide.plugins.PluginManagerCore.getPlugin]). The `$keeper` dynamic variable is
+     * registered only when optional `com.jetbrains.restClient` loads `keeper-http-client.xml`.
      */
->>>>>>> 0759420 (fix(marketplace): v2.0.2 -- fix deprecated/internal APIs, add 2026.2 EAP verification)
     private fun isHttpClientRequestFile(editor: Editor): Boolean {
         val file: VirtualFile = FileDocumentManager.getInstance().getFile(editor.document) ?: return false
         if (!isHttpClientPluginEnabled()) return false


### PR DESCRIPTION
## Summary

- Replaces `PluginManagerCore.getPlugin()` (internal API) with `PluginManager.isPluginInstalled()` for HTTP Client detection
- Replaces deprecated `JBUI.CurrentTheme.Link.linkColor()` with `Link.Foreground.ENABLED`
- Removes empty optional Python dependency declaration (no runtime effect since v1.x)
- Upgrades Kotlin from 2.2.0 to 2.4.0 (required to compile against the 2026.2 EAP bundled Kotlin runtime)
- Adds IU-262.8665.81 to `pluginVerification` and `-Deap.require.license=true` to `runIde` so the Trial widget appears during local testing

**Intentionally keeps `isConfigurationSingletonByDefault()`** rather than migrating to `getSingletonPolicy()`. The v2.0.1 submission failed JetBrains' `testTrialWidgetPresence` live UI check on build 262.8665.81 after that migration. Static verification confirms both `IU-243.26574.91` and `IU-262.8665.81` are Compatible (deprecation warnings only, no broken APIs).

## Breaking Changes

None.

## Test plan

- [x] `./gradlew verifyPlugin` passes for both IU-243.26574.91 and IU-262.8665.81 (Compatible, deprecation warnings only)
- [x] `./gradlew test` passes
- [ ] Marketplace live checker (`testTrialWidgetPresence`) -- confirmed after submission